### PR TITLE
Add NWConnection WebSocket client and Node.js native WS client

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,197 +1,100 @@
-[![Contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
-[![Issues][issues-shield]][issues-url]
-[![MIT License][license-shield]][license-url]
-[![LinkedIn][linkedin-shield]][linkedin-url]
+WebSocket
+==========
 
-<!-- PROJECT LOGO -->
+See the [project website][docs] for documentation and APIs.
 
-<br />
-<p align="center">
-<h3 align="center">WebSocket</h3>
+WebSocket is a Kotlin Multiplatform library providing RFC 6455 compliant WebSocket client
+functionality with permessage-deflate compression (RFC 7692).
 
-<p align="center">
-A kotlin multiplatform library that allows you to connect a client websocket to websocket server.
-<br />
-Fully tested on all platforms using the extensive Autobahn test suite.
-<!-- <a href="https://github.com/DitchOoM/websocket"><strong>Explore the docs »</strong></a> -->
-<br />
-<br />
-<!-- <a href="https://github.com/DitchOoM/websocket">View Demo</a>
-· -->
-<a href="https://github.com/DitchOoM/websocket/issues">Report Bug</a>
-·
-<a href="https://github.com/DitchOoM/websocket/issues">Request Feature</a>
-</p>
+- **JVM/Android**: Built on `AsynchronousSocketChannel` (NIO2)
+- **iOS/macOS/tvOS/watchOS**: `NWConnection` via Network.framework
+- **Linux**: io_uring or epoll with direct zlib
+- **Node.js/Browser**: Native WebSocket API
 
+## Features
 
-<details open="open">
-  <summary>Table of Contents</summary>
-  <ol>
-    <li>
-      <a href="#about-the-project">About The Project</a>
-      <ul>
-        <li><a href="#runtime-dependencies">Runtime Dependencies</a></li>
-      </ul>
-      <ul>
-        <li><a href="#supported-platforms">Supported Platforms</a></li>
-      </ul>
-    </li>
-    <li><a href="#installation">Installation</a></li>
-    <li>
-      <a href="#usage">Usage</a>
-      <ul>
-        <li><a href="#suspend-connect-read-write-and-close">Suspend connect, read, write and close</a></li>
-        <li><a href="#Server-example">Server example</a></li>
-        <li><a href="#TLS-support">TLS Support</a></li>
-        <li><a href="#Client-echo-example">Client echo example</a></li>
-        <li><a href="#Server-echo-example">Server echo example</a></li>
-      </ul>
-    </li>
-    <li>
-      <a href="#building-locally">Building Locally</a>
-    </li>
-    <li><a href="#getting-started">Getting Started</a></li>
-    <li><a href="#roadmap">Roadmap</a></li>
-    <li><a href="#contributing">Contributing</a></li>
-    <li><a href="#license">License</a></li>
-  </ol>
-</details>
-
-## About The Project
-
-Managing a websocket client can be slightly different based on each platform. This project aims to make
-it **easier to manage websockets in a cross platform way using kotlin multiplatform**. This was
-originally created as a side project for a kotlin multiplatform mqtt data sync solution.
-
-### Runtime Dependencies
-
-* [Buffer](https://github.com/DitchOoM/buffer)
-
-### [Supported Platforms](https://kotlinlang.org/docs/reference/mpp-supported-platforms.html)
-
-|      Platform      | 🛠Builds🛠 + 🔬Tests🔬 |  
-|:------------------:|:----------------------:|
-|     `JVM` 1.8      |           🚀           |
-|     `Node.js`      |           🚀           |
-| `Browser` (Chrome) |           🚀           |
-|     `Android`      |           🚀           |
-|       `iOS`        |           🚀           |
-|     `WatchOS`      |           🚀           |
-|       `TvOS`       |           🚀           |
-|      `MacOS`       |           🚀           |
-|    `Linux X64`     |           🔮           |
-|   `Windows X64`    |           🔮           |
+- **Suspend-based API**: All I/O operations are coroutine-friendly suspend functions
+- **Flow-based messages**: Receive messages via `incomingMessages: Flow<WebSocketMessage>`
+- **Compression**: permessage-deflate with context takeover and custom window bits
+- **Zero-copy frame pipeline**: Direct buffer I/O with SIMD-optimized masking
+- **Full RFC 6455 compliance**: Passes all 517 Autobahn test cases
 
 ## Installation
 
-- Add `implementation("com.ditchoom:websocket:$version")` to your `build.gradle` dependencies
-- Copy the contents of this [patch.js](https://github.com/DitchOoM/websocket/blob/main/webpack.config.d/patch.js) file
-  into
-  your own `webpack.config.d` directory if you are targeting `js`
-- Add this to your `kotlin {` bracket in build.gradle.kts if you are targeting an apple platform
+[![Maven Central](https://img.shields.io/maven-central/v/com.ditchoom/websocket.svg)](https://central.sonatype.com/artifact/com.ditchoom/websocket)
 
-```
-kotlin {
-  ...
-    cocoapods {
-        ios.deploymentTarget = "13.0"
-        osx.deploymentTarget = "11.0"
-        watchos.deploymentTarget = "6.0"
-        tvos.deploymentTarget = "13.0"
-        pod("SocketWrapper") {
-            source = git("https://github.com/DitchOoM/apple-socket-wrapper.git") {
-                tag = "0.1.1"
-            }
-        }
-    }
+```kotlin
+dependencies {
+    implementation("com.ditchoom:websocket:<latest-version>")
 }
 ```
 
-## Client WebSocket Usage
+Find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.ditchoom/websocket).
 
-### Suspend connect read write and close
-
-```kotlin
-// Run in a coroutine scope
-val connectionOptions = WebSocketConnectionOptions(name = "localhost", port = 8081, websocketEndpoint = "/echo")
-val websocket = WebSocketClient.Companion.allocate(connectionOptions)
-websocket.connect()
-val string1 = "test"
-websocket.write(string1)
-val dataRead = websocket.read() as DataRead.StringDataRead
-val stringReceived = dataRead.string
-websocket.close()
-```
-
-### TLS support
+## Quick Example
 
 ```kotlin
-// Simply add tls=true or change
-val connectionOptions = WebSocketConnectionOptions(name = "localhost", port = 443, websocketEndpoint = "/echo", tls = true)
+val options = WebSocketConnectionOptions(
+    name = "echo.websocket.org",
+    port = 443,
+    tls = true,
+)
+val client = WebSocketClient.allocate(options).connect()
 
+// Send a message
+client.write("Hello, WebSocket!")
+
+// Receive messages
+client.incomingMessages.collect { message ->
+    when (message) {
+        is WebSocketMessage.Text -> println("Received: ${message.value}")
+        is WebSocketMessage.Binary -> println("Binary: ${message.value.remaining()} bytes")
+    }
+}
+
+client.close()
 ```
 
-## Building Locally
+## Compression
 
-- `git clone git@github.com:DitchOoM/websocket.git`
-- Open cloned directory with [Intellij IDEA](https://www.jetbrains.com/idea/download).
-    - Be sure
-      to [open with gradle](https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start)
+Request permessage-deflate compression for reduced bandwidth:
 
-## Roadmap
+```kotlin
+val options = WebSocketConnectionOptions(
+    name = "example.com",
+    requestCompression = true,
+    compressionOptions = CompressionOptions(
+        clientNoContextTakeover = false, // maintain LZ77 window across messages
+        serverNoContextTakeover = false,
+    ),
+)
+```
 
-See the [open issues](https://github.com/DitchOoM/websocket/issues) for a list of proposed features (
-and known issues).
+## Platform Support
 
-## Contributing
-
-Contributions are what make the open source community such an amazing place to be learn, inspire,
-and create. Any contributions you make are **greatly appreciated**.
-
-1. Fork the Project
-2. Create your Feature Branch (`git checkout -b feature/AmazingFeature`)
-3. Commit your Changes (`git commit -m 'Add some AmazingFeature'`)
-4. Push to the Branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+| Platform | Implementation | Compression |
+|----------|---------------|-------------|
+| JVM 1.8+ | NIO2 AsyncSocketChannel | Context takeover, max_window_bits=15 |
+| Android | Same as JVM | Same as JVM |
+| iOS/macOS/tvOS/watchOS | NWConnection | Context takeover |
+| Linux x64/ARM64 | io_uring / epoll | Context takeover + custom window bits |
+| Node.js | Native WebSocket | No context takeover |
+| Browser | Native WebSocket | Handled by browser |
 
 ## License
 
-Distributed under the Apache 2.0 License. See `LICENSE` for more information.
+    Copyright 2022 DitchOoM
 
-[contributors-shield]: https://img.shields.io/github/contributors/DitchOoM/websocket.svg?style=for-the-badge
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
 
-[contributors-url]: https://github.com/DitchOoM/websocket/graphs/contributors
+       http://www.apache.org/licenses/LICENSE-2.0
 
-[forks-shield]: https://img.shields.io/github/forks/DitchOoM/websocket.svg?style=for-the-badge
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
 
-[forks-url]: https://github.com/DitchOoM/websocket/network/members
-
-[stars-shield]: https://img.shields.io/github/stars/DitchOoM/websocket.svg?style=for-the-badge
-
-[stars-url]: https://github.com/DitchOoM/websocket/stargazers
-
-[issues-shield]: https://img.shields.io/github/issues/DitchOoM/websocket.svg?style=for-the-badge
-
-[issues-url]: https://github.com/DitchOoM/websocket/issues
-
-[license-shield]: https://img.shields.io/github/license/DitchOoM/websocket.svg?style=for-the-badge
-
-[license-url]: https://github.com/DitchOoM/websocket/blob/master/LICENSE.md
-
-[linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
-
-[linkedin-url]: https://www.linkedin.com/in/thebehera
-
-[maven-central]: https://search.maven.org/search?q=com.ditchoom
-
-[npm]: https://www.npmjs.com/search?q=ditchoom-websocket
-
-[cocoapods]: https://cocoapods.org/pods/DitchOoM-websocket
-
-[apt]: https://packages.ubuntu.com/search?keywords=ditchoom&searchon=names&suite=groovy&section=all
-
-[yum]: https://pkgs.org/search/?q=DitchOoM-websocket
-
-[chocolately]: https://chocolatey.org/packages?q=DitchOoM-websocket
+[docs]: https://ditchoom.github.io/websocket/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import java.net.Socket
 import java.security.SecureRandom
 import java.util.Base64
@@ -54,19 +55,29 @@ kotlin {
         }
     }
 
+    // Configure cinterop for NW helpers (C bridge for dispatch_data_t → NSData)
+    fun KotlinNativeTarget.configureNWHelpersCinterop() {
+        compilations["main"].cinterops {
+            create("NWHelpers") {
+                defFile("src/nativeInterop/cinterop/NWHelpers.def")
+                includeDirs("src/nativeInterop/cinterop")
+            }
+        }
+    }
+
     // Apple targets (only on macOS host)
     if (hostOs.family.isAppleFamily) {
-        macosX64()
-        macosArm64()
-        iosArm64()
-        iosSimulatorArm64()
-        iosX64()
-        tvosArm64()
-        tvosSimulatorArm64()
-        tvosX64()
-        watchosArm64()
-        watchosSimulatorArm64()
-        watchosX64()
+        macosX64 { configureNWHelpersCinterop() }
+        macosArm64 { configureNWHelpersCinterop() }
+        iosArm64 { configureNWHelpersCinterop() }
+        iosSimulatorArm64 { configureNWHelpersCinterop() }
+        iosX64 { configureNWHelpersCinterop() }
+        tvosArm64 { configureNWHelpersCinterop() }
+        tvosSimulatorArm64 { configureNWHelpersCinterop() }
+        tvosX64 { configureNWHelpersCinterop() }
+        watchosArm64 { configureNWHelpersCinterop() }
+        watchosSimulatorArm64 { configureNWHelpersCinterop() }
+        watchosX64 { configureNWHelpersCinterop() }
     }
 
     // Linux targets (only on Linux host)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=4g
 org.gradle.parallel=true
 org.gradle.caching=true
 kotlin.mpp.stability.nowarn=true
+kotlin.mpp.enableCInteropCommonization=true
 libraryName=Websocket
 libraryDescription=Simple multiplatform kotlin coroutines based websocket.
 publishedGroupId=com.ditchoom

--- a/src/appleMain/kotlin/com/ditchoom/websocket/Factory.kt
+++ b/src/appleMain/kotlin/com/ditchoom/websocket/Factory.kt
@@ -10,4 +10,9 @@ actual fun WebSocketClient.Companion.allocate(
     connectionOptions: WebSocketConnectionOptions,
     parentScope: CoroutineScope?,
     allocationZone: AllocationZone,
-): WebSocketClient = DefaultWebSocketClient(connectionOptions, parentScope, allocationZone)
+): WebSocketClient =
+    if (connectionOptions.useNativePlatformClient) {
+        NWWebSocketClient(connectionOptions, parentScope)
+    } else {
+        DefaultWebSocketClient(connectionOptions, parentScope, allocationZone)
+    }

--- a/src/appleMain/kotlin/com/ditchoom/websocket/NWWebSocketClient.kt
+++ b/src/appleMain/kotlin/com/ditchoom/websocket/NWWebSocketClient.kt
@@ -1,0 +1,428 @@
+@file:OptIn(ExperimentalForeignApi::class, kotlinx.cinterop.BetaInteropApi::class)
+
+package com.ditchoom.websocket
+
+import com.ditchoom.buffer.ByteOrder
+import com.ditchoom.buffer.NSDataBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.toNativeData
+import com.ditchoom.websocket.nwhelpers.nw_helper_ws_receive_message
+import com.ditchoom.websocket.nwhelpers.nw_helper_ws_send
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.toKString
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
+import platform.Foundation.NSData
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import platform.Network._nw_parameters_configure_protocol_disable
+import platform.Network.nw_connection_cancel
+import platform.Network.nw_connection_create
+import platform.Network.nw_connection_set_queue
+import platform.Network.nw_connection_set_state_changed_handler
+import platform.Network.nw_connection_start
+import platform.Network.nw_connection_state_cancelled
+import platform.Network.nw_connection_state_failed
+import platform.Network.nw_connection_state_ready
+import platform.Network.nw_connection_state_waiting
+import platform.Network.nw_connection_t
+import platform.Network.nw_endpoint_create_url
+import platform.Network.nw_error_domain_dns
+import platform.Network.nw_error_domain_posix
+import platform.Network.nw_error_domain_tls
+import platform.Network.nw_error_get_error_code
+import platform.Network.nw_error_get_error_domain
+import platform.Network.nw_parameters_copy_default_protocol_stack
+import platform.Network.nw_parameters_create_secure_tcp
+import platform.Network.nw_protocol_stack_prepend_application_protocol
+import platform.Network.nw_ws_close_code_normal_closure
+import platform.Network.nw_ws_create_options
+import platform.Network.nw_ws_opcode_binary
+import platform.Network.nw_ws_opcode_close
+import platform.Network.nw_ws_opcode_ping
+import platform.Network.nw_ws_opcode_pong
+import platform.Network.nw_ws_opcode_text
+import platform.Network.nw_ws_options_add_subprotocol
+import platform.Network.nw_ws_options_set_auto_reply_ping
+import platform.Network.nw_ws_version_13
+import platform.darwin.dispatch_get_global_queue
+import platform.posix.QOS_CLASS_USER_INITIATED
+import platform.posix.strerror
+import kotlin.concurrent.Volatile
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+@OptIn(UnsafeNumber::class)
+class NWWebSocketClient(
+    private val connectionOptions: WebSocketConnectionOptions,
+    parentScope: CoroutineScope?,
+) : WebSocketClient {
+    override val scope =
+        if (parentScope == null) {
+            CoroutineScope(
+                Dispatchers.Default +
+                    CoroutineName(
+                        "NWWebSocket #${getCountForConnection(connectionOptions)}" +
+                            ": ${connectionOptions.name}:${connectionOptions.port}",
+                    ),
+            )
+        } else {
+            parentScope + Dispatchers.Default +
+                CoroutineName(
+                    "NWWebSocket #${getCountForConnection(connectionOptions)}" +
+                        ": ${connectionOptions.name}:${connectionOptions.port}",
+                )
+        }
+
+    private var connection: nw_connection_t = null
+
+    @Volatile
+    private var closedLocally = false
+
+    private val connectionStateFlow = MutableStateFlow<ConnectionState>(ConnectionState.Initialized)
+    override val connectionState = connectionStateFlow.asStateFlow()
+
+    private val incomingMessageChannel = Channel<WebSocketMessage>(Channel.UNLIMITED)
+    override val incomingMessages = incomingMessageChannel.receiveAsFlow()
+
+    private val incomingTextChannel = Channel<String>(Channel.UNLIMITED)
+    override val incomingTextMessages: Flow<String> = incomingTextChannel.receiveAsFlow()
+
+    private val incomingBinaryChannel = Channel<ReadBuffer>(Channel.UNLIMITED)
+    override val incomingBinaryMessages: Flow<ReadBuffer> = incomingBinaryChannel.receiveAsFlow()
+
+    override suspend fun localPort(): Int = -1
+
+    override suspend fun remotePort(): Int = connectionOptions.port
+
+    override suspend fun connect(): WebSocketClient {
+        if (connectionState.value == ConnectionState.Connecting ||
+            connectionState.value is ConnectionState.Connected
+        ) {
+            return this
+        }
+        connectionStateFlow.value = ConnectionState.Connecting
+
+        // Use wss/ws scheme so NW's WebSocket layer uses the URL path for the
+        // HTTP upgrade request. NW won't double-add WS since we manually prepend it.
+        val url = connectionOptions.buildUrl()
+        val endpoint = nw_endpoint_create_url(url)
+            ?: throw IllegalArgumentException("Invalid endpoint URL: $url")
+
+        val wsOptions = nw_ws_create_options(nw_ws_version_13)
+        nw_ws_options_set_auto_reply_ping(wsOptions, true)
+        for (protocol in connectionOptions.protocols) {
+            nw_ws_options_add_subprotocol(wsOptions, protocol)
+        }
+
+        val parameters = if (connectionOptions.tls) {
+            nw_parameters_create_secure_tcp(
+                { _ -> }, // Default TLS config
+                { _ -> }, // Default TCP config
+            )
+        } else {
+            nw_parameters_create_secure_tcp(
+                _nw_parameters_configure_protocol_disable, // No TLS
+                { _ -> }, // Default TCP config
+            )
+        }
+
+        if (parameters == null) {
+            connectionStateFlow.value = ConnectionState.Disconnected(Exception("Failed to create NW parameters"))
+            return this
+        }
+
+        val stack = nw_parameters_copy_default_protocol_stack(parameters)
+        nw_protocol_stack_prepend_application_protocol(stack, wsOptions)
+
+        val conn = nw_connection_create(endpoint, parameters)
+        if (conn == null) {
+            connectionStateFlow.value = ConnectionState.Disconnected(Exception("Failed to create NW connection"))
+            return this
+        }
+        connection = conn
+
+        val queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED.toLong(), 0u)
+
+        try {
+            withTimeout(connectionOptions.connectionTimeout) {
+                suspendCancellableCoroutine<Unit> { cont ->
+                    nw_connection_set_state_changed_handler(conn) { state, error ->
+                        when (state) {
+                            nw_connection_state_ready -> {
+                                connectionStateFlow.value = ConnectionState.Connected
+                                if (cont.isActive) cont.resume(Unit)
+                            }
+                            nw_connection_state_failed -> {
+                                val errorMsg = describeNWError(error)
+                                connectionStateFlow.update { current ->
+                                    if (current !is ConnectionState.Disconnected) {
+                                        ConnectionState.Disconnected(Exception(errorMsg))
+                                    } else {
+                                        current
+                                    }
+                                }
+                                if (cont.isActive) {
+                                    cont.resumeWithException(Exception("Connection failed: $errorMsg"))
+                                }
+                            }
+                            nw_connection_state_waiting -> {
+                                val errorMsg = describeNWError(error)
+                                connectionStateFlow.update { current ->
+                                    if (current !is ConnectionState.Disconnected) {
+                                        ConnectionState.Disconnected(Exception("Waiting: $errorMsg"))
+                                    } else {
+                                        current
+                                    }
+                                }
+                                nw_connection_cancel(conn)
+                                if (cont.isActive) {
+                                    cont.resumeWithException(Exception("Connection waiting: $errorMsg"))
+                                }
+                            }
+                            nw_connection_state_cancelled -> {
+                                connectionStateFlow.update { current ->
+                                    if (current !is ConnectionState.Disconnected) {
+                                        ConnectionState.Disconnected()
+                                    } else {
+                                        current
+                                    }
+                                }
+                                closeChannels()
+                            }
+                        }
+                    }
+
+                    nw_connection_set_queue(conn, queue)
+                    nw_connection_start(conn)
+
+                    cont.invokeOnCancellation {
+                        nw_connection_cancel(conn)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            connectionStateFlow.value = ConnectionState.Disconnected(e)
+            return this
+        }
+
+        receiveNextMessage()
+        return this
+    }
+
+    private fun receiveNextMessage() {
+        val conn = connection ?: return
+        if (closedLocally) return
+
+        nw_helper_ws_receive_message(conn) { data, opcode, closeCode, isCompleteNumber, error ->
+            if (error != null) {
+                connectionStateFlow.update { current ->
+                    if (current !is ConnectionState.Disconnected) {
+                        ConnectionState.Disconnected(Exception(error.localizedDescription))
+                    } else {
+                        current
+                    }
+                }
+                closeChannels()
+                return@nw_helper_ws_receive_message
+            }
+
+            // Process WebSocket opcode
+            val shouldContinue = handleOpcode(opcode, closeCode, data)
+
+            // Continue receiving unless we got a close frame or closed locally.
+            // Note: isComplete from nw_connection_receive_message means the current
+            // message is fully assembled, NOT that the connection is done.
+            if (shouldContinue && !closedLocally) {
+                receiveNextMessage()
+            }
+        }
+    }
+
+    /**
+     * Process a received WebSocket opcode. Returns true if we should continue receiving.
+     */
+    private fun handleOpcode(opcode: Int, closeCode: Int, data: NSData?): Boolean {
+        when (opcode) {
+            nw_ws_opcode_text -> {
+                if (data != null && data.length.toInt() > 0) {
+                    val text = NSString.create(data = data, encoding = NSUTF8StringEncoding)?.toString()
+                    if (text != null) {
+                        incomingMessageChannel.trySend(WebSocketMessage.Text(text))
+                        incomingTextChannel.trySend(text)
+                    }
+                }
+            }
+            nw_ws_opcode_binary -> {
+                if (data != null && data.length.toInt() > 0) {
+                    val buffer = NSDataBuffer(data, ByteOrder.BIG_ENDIAN)
+                    incomingMessageChannel.trySend(WebSocketMessage.Binary(buffer))
+                    incomingBinaryChannel.trySend(buffer)
+                }
+            }
+            nw_ws_opcode_close -> {
+                val reason = if (data != null && data.length.toInt() > 0) {
+                    NSString.create(data = data, encoding = NSUTF8StringEncoding)?.toString() ?: ""
+                } else {
+                    ""
+                }
+                incomingMessageChannel.trySend(
+                    WebSocketMessage.Close(closeCode.toUShort(), reason),
+                )
+                connectionStateFlow.update { current ->
+                    if (current !is ConnectionState.Disconnected) {
+                        ConnectionState.Disconnected(
+                            code = closeCode.toUShort(),
+                            reason = reason,
+                        )
+                    } else {
+                        current
+                    }
+                }
+                closeChannels()
+                return false
+            }
+            nw_ws_opcode_ping -> {
+                if (data != null && data.length.toInt() > 0) {
+                    val buffer = NSDataBuffer(data, ByteOrder.BIG_ENDIAN)
+                    incomingMessageChannel.trySend(WebSocketMessage.Ping(buffer))
+                } else {
+                    incomingMessageChannel.trySend(
+                        WebSocketMessage.Ping(ReadBuffer.EMPTY_BUFFER),
+                    )
+                }
+            }
+            nw_ws_opcode_pong -> {
+                if (data != null && data.length.toInt() > 0) {
+                    val buffer = NSDataBuffer(data, ByteOrder.BIG_ENDIAN)
+                    incomingMessageChannel.trySend(WebSocketMessage.Pong(buffer))
+                } else {
+                    incomingMessageChannel.trySend(
+                        WebSocketMessage.Pong(ReadBuffer.EMPTY_BUFFER),
+                    )
+                }
+            }
+        }
+        return true
+    }
+
+    /**
+     * Async send via C helper — creates WS metadata + context in C,
+     * then calls nw_connection_send and suspends until completion.
+     */
+    private suspend fun sendSuspend(
+        conn: nw_connection_t,
+        nsData: NSData?,
+        opcode: Int,
+        closeCode: Int = 0,
+    ) {
+        suspendCancellableCoroutine<Unit> { cont ->
+            nw_helper_ws_send(conn, nsData, opcode, closeCode) { error ->
+                if (error != null) {
+                    if (cont.isActive) cont.resumeWithException(Exception(error.localizedDescription))
+                } else {
+                    if (cont.isActive) cont.resume(Unit)
+                }
+            }
+        }
+    }
+
+    override suspend fun write(string: String) {
+        val conn = connection ?: return
+        val nsData = NSString.create(string = string).dataUsingEncoding(NSUTF8StringEncoding)
+            ?: return
+        sendSuspend(conn, nsData, nw_ws_opcode_text)
+    }
+
+    override suspend fun write(buffer: ReadBuffer) {
+        val conn = connection ?: return
+        val nsData = buffer.toNativeData().nsData
+        sendSuspend(conn, nsData, nw_ws_opcode_binary)
+    }
+
+    override suspend fun isPingSupported(): Boolean = true
+
+    override suspend fun ping(payloadData: ReadBuffer) {
+        val conn = connection ?: return
+        val nsData = if (payloadData.remaining() > 0) {
+            payloadData.toNativeData().nsData
+        } else {
+            null
+        }
+        sendSuspend(conn, nsData, nw_ws_opcode_ping)
+    }
+
+    override suspend fun close() {
+        if (closedLocally) return
+        closedLocally = true
+
+        val conn = connection
+        if (conn != null) {
+            // Try to send a clean WebSocket close frame, then cancel
+            try {
+                sendSuspend(conn, null, nw_ws_opcode_close, nw_ws_close_code_normal_closure.toInt())
+            } catch (_: Exception) {
+                // Ignore send errors during close — connection may already be gone
+            }
+            nw_connection_cancel(conn)
+        }
+
+        closeChannels()
+        connectionStateFlow.update { current ->
+            if (current !is ConnectionState.Disconnected) {
+                ConnectionState.Disconnected()
+            } else {
+                current
+            }
+        }
+        connection = null
+    }
+
+    private fun closeChannels() {
+        incomingMessageChannel.close()
+        incomingTextChannel.close()
+        incomingBinaryChannel.close()
+    }
+
+    companion object {
+        private val countMap = mutableMapOf<String, Int>()
+
+        private fun getCountForConnection(connectionOptions: WebSocketConnectionOptions): Int {
+            val key = "${connectionOptions.name}:${connectionOptions.port}"
+            val value = countMap[key]
+            return if (value == null) {
+                countMap[key] = 1
+                1
+            } else {
+                val newCount = value + 1
+                countMap[key] = newCount
+                newCount
+            }
+        }
+
+        private fun describeNWError(error: platform.Network.nw_error_t): String {
+            if (error == null) return "Unknown error"
+            val domain = nw_error_get_error_domain(error)
+            val code = nw_error_get_error_code(error)
+            return when (domain) {
+                nw_error_domain_posix -> "POSIX error $code: ${strerror(code)?.toKString() ?: "unknown"}"
+                nw_error_domain_dns -> "DNS error $code"
+                nw_error_domain_tls -> "TLS error $code"
+                else -> "Network error (domain=$domain, code=$code)"
+            }
+        }
+    }
+}

--- a/src/commonMain/kotlin/com/ditchoom/websocket/WebSocketConnectionOptions.kt
+++ b/src/commonMain/kotlin/com/ditchoom/websocket/WebSocketConnectionOptions.kt
@@ -36,6 +36,7 @@ data class WebSocketConnectionOptions(
     val protocols: List<String> = emptyList(),
     val requestCompression: Boolean = false,
     val compressionOptions: CompressionOptions = CompressionOptions(),
+    val useNativePlatformClient: Boolean = true,
 ) {
     internal fun buildUrl(): String {
         val prefix =

--- a/src/jsMain/kotlin/com/ditchoom/websocket/NodeJsWebSocketClient.kt
+++ b/src/jsMain/kotlin/com/ditchoom/websocket/NodeJsWebSocketClient.kt
@@ -1,0 +1,243 @@
+package com.ditchoom.websocket
+
+import com.ditchoom.buffer.JsBuffer
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.ReadBuffer.Companion.EMPTY_BUFFER
+import com.ditchoom.socket.SocketClosedException
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.withTimeout
+import org.khronos.webgl.Int8Array
+import org.khronos.webgl.Uint8Array
+
+class NodeJsWebSocketClient(
+    private val connectionOptions: WebSocketConnectionOptions,
+    parentScope: CoroutineScope?,
+    private val wsModule: dynamic,
+) : WebSocketClient {
+    override val scope =
+        if (parentScope == null) {
+            CoroutineScope(
+                Dispatchers.Default +
+                    CoroutineName(
+                        "NodeWS #${getCountForConnection(connectionOptions)}" +
+                            ": ${connectionOptions.name}:${connectionOptions.port}",
+                    ),
+            )
+        } else {
+            parentScope + Dispatchers.Default +
+                CoroutineName(
+                    "NodeWS #${getCountForConnection(connectionOptions)}" +
+                        ": ${connectionOptions.name}:${connectionOptions.port}",
+                )
+        }
+
+    private val url = connectionOptions.buildUrl()
+    private var ws: dynamic = null
+
+    private val connectionStateFlow = MutableStateFlow<ConnectionState>(ConnectionState.Initialized)
+    override val connectionState = connectionStateFlow.asStateFlow()
+
+    private val incomingMessageChannel = Channel<WebSocketMessage>(Channel.UNLIMITED)
+    override val incomingMessages = incomingMessageChannel.receiveAsFlow()
+
+    private val incomingTextChannel = Channel<String>(Channel.UNLIMITED)
+    override val incomingTextMessages: Flow<String> = incomingTextChannel.receiveAsFlow()
+
+    private val incomingBinaryChannel = Channel<ReadBuffer>(Channel.UNLIMITED)
+    override val incomingBinaryMessages: Flow<ReadBuffer> = incomingBinaryChannel.receiveAsFlow()
+
+    override suspend fun localPort(): Int {
+        val socket = ws?._socket ?: return -1
+        return (socket.localPort as? Number)?.toInt() ?: -1
+    }
+
+    override suspend fun remotePort(): Int {
+        val socket = ws?._socket ?: return connectionOptions.port
+        return (socket.remotePort as? Number)?.toInt() ?: connectionOptions.port
+    }
+
+    override suspend fun connect(): WebSocketClient {
+        connectionStateFlow.value = ConnectionState.Connecting
+
+        // Build ws options
+        val options = js("{}")
+        options.handshakeTimeout = connectionOptions.connectionTimeout.inWholeMilliseconds.toInt()
+        if (connectionOptions.requestCompression) {
+            options.perMessageDeflate = true
+        }
+
+        // Create WebSocket instance using Reflect.construct for dynamic constructor call
+        val protocols =
+            if (connectionOptions.protocols.isNotEmpty()) {
+                connectionOptions.protocols.toTypedArray()
+            } else {
+                js("undefined")
+            }
+        val args = js("[]")
+        args.push(url)
+        args.push(protocols)
+        args.push(options)
+        ws = js("Reflect").construct(wsModule, args)
+
+        val wsInstance = ws
+
+        // Register event handlers using Node.js EventEmitter .on() pattern
+        wsInstance.on("open", fun() {
+            connectionStateFlow.value = ConnectionState.Connected
+        })
+
+        wsInstance.on("close", fun(code: dynamic, reason: dynamic) {
+            val closeCode = (code as? Number)?.toInt()?.toUShort() ?: 1006u.toUShort()
+            val closeReason =
+                if (reason != null && reason != undefined) {
+                    // reason is a Buffer in ws module; decode to string
+                    reason.toString("utf8") as String
+                } else {
+                    ""
+                }
+            connectionStateFlow.value =
+                ConnectionState.Disconnected(code = closeCode, reason = closeReason)
+            closeInternal()
+        })
+
+        wsInstance.on("error", fun(err: dynamic) {
+            val message = err?.message?.toString() ?: "WebSocket error"
+            if (connectionState.value !is ConnectionState.Disconnected) {
+                connectionStateFlow.value = ConnectionState.Disconnected(Exception(message))
+            }
+            closeInternal()
+        })
+
+        wsInstance.on("message", fun(data: dynamic, isBinary: Boolean) {
+            if (isBinary) {
+                val buffer = nodeBufferToJsBuffer(data)
+                scope.launch {
+                    incomingMessageChannel.trySend(WebSocketMessage.Binary(buffer))
+                    incomingBinaryChannel.trySend(buffer)
+                }
+            } else {
+                val text = data.toString()
+                scope.launch {
+                    incomingMessageChannel.trySend(WebSocketMessage.Text(text))
+                    incomingTextChannel.trySend(text)
+                }
+            }
+        })
+
+        wsInstance.on("ping", fun(data: dynamic) {
+            val buffer =
+                if (data != null && data != undefined) nodeBufferToJsBuffer(data) else EMPTY_BUFFER
+            scope.launch {
+                incomingMessageChannel.trySend(WebSocketMessage.Ping(buffer))
+            }
+        })
+
+        wsInstance.on("pong", fun(data: dynamic) {
+            val buffer =
+                if (data != null && data != undefined) nodeBufferToJsBuffer(data) else EMPTY_BUFFER
+            scope.launch {
+                incomingMessageChannel.trySend(WebSocketMessage.Pong(buffer))
+            }
+        })
+
+        // Wait for connection
+        withTimeout(connectionOptions.connectionTimeout) {
+            when (val state = connectionState.value) {
+                ConnectionState.Initialized, ConnectionState.Connecting -> {
+                    connectionState.first {
+                        it is ConnectionState.Connected || it is ConnectionState.Disconnected
+                    }
+                    val currentState = connectionState.value
+                    if (currentState is ConnectionState.Disconnected) {
+                        throw SocketClosedException(
+                            "Failed to connect. Reason: ${currentState.reason}, Code: ${currentState.code}",
+                            currentState.t,
+                        )
+                    }
+                }
+                is ConnectionState.Disconnected ->
+                    throw SocketClosedException(
+                        "Failed to connect. Reason: ${state.reason}, Code: ${state.code}",
+                        state.t,
+                    )
+                ConnectionState.Connected -> {}
+            }
+        }
+
+        return this
+    }
+
+    override suspend fun write(string: String) {
+        ws?.send(string)
+    }
+
+    override suspend fun write(buffer: ReadBuffer) {
+        val jsBuffer = buffer as JsBuffer
+        val uint8Array = Uint8Array(jsBuffer.buffer.buffer, 0, buffer.limit())
+        ws?.send(uint8Array)
+    }
+
+    override suspend fun isPingSupported(): Boolean = true
+
+    override suspend fun ping(payloadData: ReadBuffer) {
+        if (payloadData.remaining() > 0) {
+            val jsBuffer = payloadData as JsBuffer
+            val uint8Array = Uint8Array(jsBuffer.buffer.buffer, 0, payloadData.limit())
+            ws?.ping(uint8Array)
+        } else {
+            ws?.ping()
+        }
+    }
+
+    override suspend fun close() {
+        try {
+            ws?.close(1000)
+        } catch (_: dynamic) {
+            // Ignore close errors
+        }
+        closeInternal()
+    }
+
+    private fun closeInternal() {
+        incomingMessageChannel.close()
+        incomingTextChannel.close()
+        incomingBinaryChannel.close()
+    }
+
+    private fun nodeBufferToJsBuffer(data: dynamic): ReadBuffer {
+        // Node.js Buffer is a Uint8Array subclass
+        val uint8 = data.unsafeCast<Uint8Array>()
+        val int8 = Int8Array(uint8.buffer, uint8.byteOffset, uint8.length)
+        val jsBuffer = JsBuffer(int8)
+        jsBuffer.setLimit(int8.length)
+        jsBuffer.position(0)
+        return jsBuffer.slice()
+    }
+
+    companion object {
+        private val countMap = mutableMapOf<String, Int>()
+
+        private fun getCountForConnection(connectionOptions: WebSocketConnectionOptions): Int {
+            val key = "${connectionOptions.name}:${connectionOptions.port}"
+            val value = countMap[key]
+            return if (value == null) {
+                countMap[key] = 1
+                1
+            } else {
+                val newCount = value + 1
+                countMap[key] = newCount
+                newCount
+            }
+        }
+    }
+}

--- a/src/jsMain/kotlin/com/ditchoom/websocket/WebSocket.kt
+++ b/src/jsMain/kotlin/com/ditchoom/websocket/WebSocket.kt
@@ -1,13 +1,26 @@
 package com.ditchoom.websocket
 
 import com.ditchoom.buffer.AllocationZone
+import com.ditchoom.buffer.pool.BufferPool
+import com.ditchoom.socket.isNodeJs
 import kotlinx.coroutines.CoroutineScope
 
 internal actual val supportsCustomDeflateWindowBits: Boolean = false
 internal actual val supportsDeflateContextTakeover: Boolean = false
 
+private val wsModule: dynamic = js("try { require('ws') } catch(e) { null }")
+
 actual fun WebSocketClient.Companion.allocate(
     connectionOptions: WebSocketConnectionOptions,
     parentScope: CoroutineScope?,
     allocationZone: AllocationZone,
-): WebSocketClient = DefaultWebSocketClient(connectionOptions, parentScope, allocationZone)
+): WebSocketClient =
+    if (isNodeJs) {
+        if (connectionOptions.useNativePlatformClient && wsModule != null) {
+            NodeJsWebSocketClient(connectionOptions, parentScope, wsModule)
+        } else {
+            DefaultWebSocketClient(connectionOptions, parentScope, allocationZone)
+        }
+    } else {
+        BrowserWebSocketController(connectionOptions, BufferPool(), parentScope, allocationZone)
+    }

--- a/src/nativeInterop/cinterop/NWHelpers.def
+++ b/src/nativeInterop/cinterop/NWHelpers.def
@@ -1,0 +1,93 @@
+language = Objective-C
+package = com.ditchoom.websocket.nwhelpers
+headers = nw_helpers.h
+headerFilter = nw_helpers.h
+linkerOpts = -framework Network -framework Foundation
+---
+#include <Network/Network.h>
+#include <Foundation/Foundation.h>
+
+void nw_helper_receive(
+    nw_connection_t _Nonnull connection,
+    uint32_t minimum_incomplete_length,
+    uint32_t maximum_length,
+    nw_receive_nsdata_handler_t _Nonnull handler)
+{
+    nw_connection_receive(connection, minimum_incomplete_length, maximum_length,
+        ^(dispatch_data_t _Nullable content, nw_content_context_t _Nullable context,
+          bool is_complete, nw_error_t _Nullable error) {
+            handler((NSData *)content, context, @(is_complete), error);
+        });
+}
+
+void nw_helper_ws_receive_message(
+    nw_connection_t _Nonnull connection,
+    nw_ws_receive_handler_t _Nonnull handler)
+{
+    nw_connection_receive_message(connection, ^(dispatch_data_t _Nullable content,
+        nw_content_context_t _Nullable context, bool is_complete, nw_error_t _Nullable error) {
+
+            __block int32_t opcode = -1;
+            __block int32_t close_code = 0;
+
+            if (context != NULL) {
+                nw_content_context_foreach_protocol_metadata(context,
+                    ^(nw_protocol_definition_t _Nonnull definition,
+                      nw_protocol_metadata_t _Nonnull metadata) {
+                        opcode = (int32_t)nw_ws_metadata_get_opcode(metadata);
+                        if (opcode == nw_ws_opcode_close) {
+                            close_code = (int32_t)nw_ws_metadata_get_close_code(metadata);
+                        }
+                    });
+            }
+
+            NSError *nsErr = nil;
+            if (error != NULL) {
+                int code = nw_error_get_error_code(error);
+                int domain = nw_error_get_error_domain(error);
+                NSString *desc = [NSString stringWithFormat:@"NW receive error domain=%d code=%d",
+                    domain, code];
+                nsErr = [[NSError alloc] initWithDomain:@"NWError" code:code
+                    userInfo:@{NSLocalizedDescriptionKey: desc}];
+            }
+
+            handler((NSData *)content, opcode, close_code, @(is_complete), nsErr);
+        });
+}
+
+void nw_helper_ws_send(
+    nw_connection_t _Nonnull connection,
+    NSData * _Nullable data,
+    int32_t opcode,
+    int32_t close_code,
+    nw_helper_send_completion_t _Nonnull completion)
+{
+    nw_protocol_metadata_t metadata = nw_ws_create_metadata((nw_ws_opcode_t)opcode);
+    if (close_code != 0) {
+        nw_ws_metadata_set_close_code(metadata, (nw_ws_close_code_t)close_code);
+    }
+
+    nw_content_context_t context = nw_content_context_create("ws");
+    nw_content_context_set_metadata_for_protocol(context, metadata);
+
+    dispatch_data_t dispatch_data = NULL;
+    if (data != nil && data.length > 0) {
+        dispatch_data = dispatch_data_create(data.bytes, data.length,
+            dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    }
+
+    nw_connection_send(connection, dispatch_data, context, true,
+        ^(nw_error_t _Nullable error) {
+            if (error == NULL) {
+                completion(nil);
+            } else {
+                int code = nw_error_get_error_code(error);
+                int domain = nw_error_get_error_domain(error);
+                NSString *desc = [NSString stringWithFormat:@"NW send error domain=%d code=%d",
+                    domain, code];
+                NSError *nsError = [[NSError alloc] initWithDomain:@"NWError"
+                    code:code userInfo:@{NSLocalizedDescriptionKey: desc}];
+                completion(nsError);
+            }
+        });
+}

--- a/src/nativeInterop/cinterop/nw_helpers.h
+++ b/src/nativeInterop/cinterop/nw_helpers.h
@@ -1,0 +1,55 @@
+#ifndef NW_HELPERS_H
+#define NW_HELPERS_H
+
+#include <Network/Network.h>
+#include <Foundation/Foundation.h>
+
+// === Receive helpers ===
+
+// Low-level receive callback — bridges dispatch_data_t → NSData.
+// Uses NSNumber for is_complete because K/N can't bridge ObjC blocks
+// with C value-type (bool) parameters.
+typedef void (^nw_receive_nsdata_handler_t)(
+    NSData * _Nullable content,
+    nw_content_context_t _Nullable context,
+    NSNumber * _Nonnull is_complete,
+    nw_error_t _Nullable error);
+
+// Wraps nw_connection_receive — bridges dispatch_data_t → NSData in callback
+void nw_helper_receive(
+    nw_connection_t _Nonnull connection,
+    uint32_t minimum_incomplete_length,
+    uint32_t maximum_length,
+    nw_receive_nsdata_handler_t _Nonnull handler);
+
+// WebSocket-aware receive callback — all NW types resolved in C.
+// Only K/N-safe types cross the boundary: NSData, int32_t, NSNumber, NSError.
+typedef void (^nw_ws_receive_handler_t)(
+    NSData * _Nullable content,
+    int32_t opcode,
+    int32_t close_code,
+    NSNumber * _Nonnull is_complete,
+    NSError * _Nullable error);
+
+// Wraps nw_connection_receive_message for WebSocket —
+// extracts opcode and close_code from context metadata in C.
+void nw_helper_ws_receive_message(
+    nw_connection_t _Nonnull connection,
+    nw_ws_receive_handler_t _Nonnull handler);
+
+// === Send helpers ===
+
+// Send completion callback — reference-type only, K/N safe.
+typedef void (^nw_helper_send_completion_t)(NSError * _Nullable error);
+
+// WebSocket-aware async send — creates WS metadata + context in C,
+// then calls nw_connection_send and invokes completion when done.
+// close_code is only applied when opcode == nw_ws_opcode_close; pass 0 otherwise.
+void nw_helper_ws_send(
+    nw_connection_t _Nonnull connection,
+    NSData * _Nullable data,
+    int32_t opcode,
+    int32_t close_code,
+    nw_helper_send_completion_t _Nonnull completion);
+
+#endif /* NW_HELPERS_H */


### PR DESCRIPTION
## Summary

- **NWWebSocketClient**: Replaces NSURLSession-based Apple WebSocket with NWConnection + NWProtocolWebSocket, using C cinterop helpers to avoid K/N block bridging crashes with `dispatch_data_t`, `nw_error_t`, and other NW framework types
- **NodeJsWebSocketClient**: Native WebSocket client for Node.js using the `ws` npm package
- **`useNativePlatformClient`** option on `WebSocketConnectionOptions` to choose between native platform clients and `DefaultWebSocketClient`

### C Cinterop Bridge (`nw_helpers.h` / `NWHelpers.def`)
All NW framework object interactions happen in C helpers. Only K/N-safe types cross the boundary: `NSData`, `NSError`, `NSNumber`, `int32_t`. This fixes crashes like:
> Converting Obj-C blocks with non-reference-typed return value to kotlin.Any is not supported

### Key bug fix
Fixed the NW receive loop to continue listening after each complete message instead of disconnecting — `isComplete` from `nw_connection_receive_message` means the current message is fully assembled, not that the connection is done.

## Test plan
- [x] `./gradlew macosArm64Test` — 198 tests pass (mosquitto timeout is external server issue)
- [x] `./gradlew jvmTest` — all pass
- [x] `./gradlew jsNodeTest` — 198 tests pass
- [x] Autobahn integration tests — all 517 cases pass on JVM
- [ ] CI validation across all platforms