### PR TITLE
feat(tcp): WebSocketTransport — WebSocket as a socket Transport rung

### DIFF
--- a/.github/workflows/autobahn.yaml
+++ b/.github/workflows/autobahn.yaml
@@ -59,7 +59,10 @@ jobs:
           cache-from: type=gha,scope=autobahn-image-${{ runner.arch }}
           cache-to: type=gha,mode=max,scope=autobahn-image-${{ runner.arch }}
       - name: Run Autobahn (JVM)
-        run: ./gradlew jvmTest -PintegrationTests --tests "$AUTOBAHN_FILTER" --no-build-cache
+        # Root task only (leading ':'): the Autobahn suites live in the root module. An unqualified
+        # task also runs :websocket-tcp:jvmTest, whose tests never match the filter — Gradle then
+        # fails that task with "No tests found for given includes".
+        run: ./gradlew :jvmTest -PintegrationTests --tests "$AUTOBAHN_FILTER" --no-build-cache
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
@@ -107,7 +110,8 @@ jobs:
         # Dump a V8 heap snapshot if Node approaches its heap limit, for post-mortem of a JS OOM.
         env:
           NODE_OPTIONS: --heapsnapshot-near-heap-limit=2
-        run: ./gradlew jsNodeTest -PintegrationTests --tests "$AUTOBAHN_FILTER" --no-build-cache
+        # Root task only — see the JVM job's comment.
+        run: ./gradlew :jsNodeTest -PintegrationTests --tests "$AUTOBAHN_FILTER" --no-build-cache
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4
@@ -154,7 +158,8 @@ jobs:
           cache-from: type=gha,scope=autobahn-image-${{ runner.arch }}
           cache-to: type=gha,mode=max,scope=autobahn-image-${{ runner.arch }}
       - name: Run Autobahn (jsBrowser)
-        run: ./gradlew jsBrowserTest -PintegrationTests --tests "$AUTOBAHN_FILTER" --no-build-cache
+        # Root task only — see the JVM job's comment.
+        run: ./gradlew :jsBrowserTest -PintegrationTests --tests "$AUTOBAHN_FILTER" --no-build-cache
       - name: Upload report
         if: always()
         uses: actions/upload-artifact@v4

--- a/gradle/setup.gradle.kts
+++ b/gradle/setup.gradle.kts
@@ -44,21 +44,34 @@ fun getLatestVersion(): Version {
     if (latestVersion != null && !latestVersion.isVersionZero()) {
         return latestVersion
     }
-    try {
-        // Always resolve the base version from the ROOT artifact so every module (root + submodules)
-        // converges on one version lineage — matches socket/buffer. Querying a per-module artifact made
-        // never-published submodules (websocket-tcp) 404 → start their own 0.0.0→1.0.0 lineage.
-        val xml = URL("https://repo1.maven.org/maven2/com/ditchoom/${rootProject.name}/maven-metadata.xml").readText()
-        val versioning = XmlParser().parseText(xml)["versioning"] as List<Node>
-        val latestStringList = versioning.first()["latest"] as List<Node>
-        val result = Version((latestStringList.first().value() as List<*>).first().toString(), false)
-        this.latestVersion = result
-        return result
-    } catch (_: Exception) {
-        val result = Version(0u, 0u, 0u, false)
-        this.latestVersion = result
-        return result
+    // Resolve the base version ONCE per build and share it via rootProject.extra: this script is
+    // applied per module (own classloader, own state), so without sharing, every module fetches
+    // Central's maven-metadata.xml independently at configuration time. While a just-published
+    // release propagates through Central's CDN those fetches can disagree, handing modules
+    // different bases — observed as the POM pre-flight's "VERSION DRIFT across websocket modules:
+    // 2.0.1 2.0.2". Stored as a String because each script classloader has its own Version class.
+    val sharedKey = "ditchoomResolvedBaseVersion"
+    if (rootProject.extra.has(sharedKey)) {
+        val shared = Version(rootProject.extra[sharedKey] as String, false)
+        this.latestVersion = shared
+        return shared
     }
+    val result =
+        try {
+            // Always resolve the base version from the ROOT artifact so every module (root + submodules)
+            // converges on one version lineage — matches socket/buffer. Querying a per-module artifact made
+            // never-published submodules (websocket-tcp) 404 → start their own 0.0.0→1.0.0 lineage.
+            val xml = URL("https://repo1.maven.org/maven2/com/ditchoom/${rootProject.name}/maven-metadata.xml").readText()
+            val versioning = XmlParser().parseText(xml)["versioning"] as List<Node>
+            val latestStringList = versioning.first()["latest"] as List<Node>
+            Version((latestStringList.first().value() as List<*>).first().toString(), false)
+        } catch (_: Exception) {
+            Version(0u, 0u, 0u, false)
+        }
+    // Share even the fetch-failed fallback: a mixed success/failure split across modules is still drift.
+    rootProject.extra.set(sharedKey, "${result.major}.${result.minor}.${result.patch}")
+    this.latestVersion = result
+    return result
 }
 
 fun getNextVersion(snapshot: Boolean): Version {

--- a/websocket-tcp/src/commonMain/kotlin/com/ditchoom/websocket/tcp/WebSocketTransport.kt
+++ b/websocket-tcp/src/commonMain/kotlin/com/ditchoom/websocket/tcp/WebSocketTransport.kt
@@ -1,0 +1,159 @@
+package com.ditchoom.websocket.tcp
+
+import com.ditchoom.buffer.Charset
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.flow.ByteStream
+import com.ditchoom.buffer.flow.BytesWritten
+import com.ditchoom.buffer.flow.Connection
+import com.ditchoom.buffer.flow.ReadPolicy
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.flow.WritePolicy
+import com.ditchoom.socket.SocketClosedException
+import com.ditchoom.socket.TransportConfig
+import com.ditchoom.socket.transport.TcpTransport
+import com.ditchoom.socket.transport.Transport
+import com.ditchoom.websocket.CompressionOptions
+import com.ditchoom.websocket.WebSocketConnectionOptions
+import com.ditchoom.websocket.WebSocketMessage
+import com.ditchoom.websocket.codecs.BinaryPassThroughCodec
+import com.ditchoom.websocket.connectWebSocket
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+
+/**
+ * WebSocket as a [Transport] rung — the inverse of [connectWebSocket]: instead of the caller
+ * bringing a [ByteStream] and getting WebSocket messages, the caller asks for a connection and
+ * gets a [ByteStream] whose bytes ride binary WebSocket frames. This is what lets WebSocket sit
+ * in a socket `FallbackTransport` chain (QUIC → WebTransport → TCP → **WebSocket**) as the
+ * universal floor: a protocol library binds to the returned [ByteStream] and never learns the
+ * bytes were framed.
+ *
+ * Per-transport addressing lives on the instance (the fallback RFC's resolved convention):
+ * [websocketEndpoint], [protocols] and compression are fixed at construction; `connect()` supplies
+ * only the uniform (host, port, config) surface. TLS follows [TransportConfig.tls] — `wss` when
+ * present, plain `ws` otherwise — so the chain's TLS-uniformity invariant is the caller's config,
+ * stated once.
+ *
+ * Semantics of the returned [ByteStream]:
+ * - `write()` sends one binary frame per call; `read()` yields one data payload per call.
+ *   Byte-stream consumers must not assume frame boundaries survive proxies — they don't need to,
+ *   since the consumer reassembles from a byte stream anyway.
+ * - Text frames are surfaced as their UTF-8 bytes: a byte pipe has no message-type channel, and
+ *   dropping data a permissive peer sent as text would corrupt the stream.
+ * - Ping/Pong are invisible (the library auto-pongs); a Close frame or EOF is [ReadResult.End].
+ * - The WebSocket-internal read loop waits forever on a quiet connection ([Duration.INFINITE]
+ *   read timeout): liveness/keepalive belongs to the protocol riding the pipe, while each
+ *   `read()`/`write()` call is still bounded by its own deadline.
+ */
+class WebSocketTransport(
+    private val websocketEndpoint: String = "/",
+    private val protocols: List<String> = emptyList(),
+    private val requestCompression: Boolean = false,
+    private val compressionOptions: CompressionOptions = CompressionOptions(),
+    private val underlying: Transport = TcpTransport(),
+    private val parentScope: CoroutineScope? = null,
+) : Transport {
+    override suspend fun connect(
+        hostname: String,
+        port: Int,
+        config: TransportConfig,
+    ): ByteStream {
+        val stream = underlying.connect(hostname, port, config)
+        val options =
+            WebSocketConnectionOptions(
+                name = hostname,
+                port = port,
+                tls = config.tls != null,
+                connectionTimeout = config.connectTimeout,
+                // A quiet WebSocket is not a dead one: the frame read loop treats a read timeout as
+                // a transport error and tears down, so the pipe must wait indefinitely for the next
+                // frame. Callers bound each ByteStream.read() with its own deadline instead.
+                readTimeout = Duration.INFINITE,
+                websocketEndpoint = websocketEndpoint,
+                protocols = protocols,
+                requestCompression = requestCompression,
+                compressionOptions = compressionOptions,
+                bufferFactory = config.bufferFactory,
+            )
+        val connection =
+            try {
+                connectWebSocket(stream, options, BinaryPassThroughCodec, parentScope)
+            } catch (t: Throwable) {
+                try {
+                    stream.close()
+                } catch (_: Exception) {
+                }
+                throw t
+            }
+        return WebSocketByteStream(connection, config)
+    }
+}
+
+/**
+ * The byte-pipe projection over a WebSocket [Connection]: write = one binary frame, read = the
+ * next data payload (control frames handled/skipped), Close/EOF = [ReadResult.End]. Closing the
+ * stream runs the full RFC 6455 close handshake and tears down the underlying transport.
+ */
+private class WebSocketByteStream(
+    private val connection: Connection<WebSocketMessage<ReadBuffer>>,
+    private val config: TransportConfig,
+) : ByteStream {
+    private var open = true
+
+    override val isOpen: Boolean get() = open
+
+    override val readPolicy: ReadPolicy get() = config.readPolicy
+
+    override val writePolicy: WritePolicy get() = config.writePolicy
+
+    override suspend fun read(deadline: Duration): ReadResult {
+        if (!open) return ReadResult.End
+        val message =
+            try {
+                withTimeout(deadline) {
+                    connection.receive().first {
+                        it !is WebSocketMessage.Ping && it !is WebSocketMessage.Pong
+                    }
+                }
+            } catch (_: NoSuchElementException) {
+                // Message channel closed (peer EOF / transport failure) — clean end of stream.
+                open = false
+                return ReadResult.End
+            }
+        return when (message) {
+            is WebSocketMessage.Binary -> ReadResult.Data(message.payload)
+            is WebSocketMessage.Text -> ReadResult.Data(message.payload.toUtf8Buffer())
+            is WebSocketMessage.Close -> {
+                open = false
+                ReadResult.End
+            }
+            is WebSocketMessage.Ping, is WebSocketMessage.Pong ->
+                error("control frames are filtered before dispatch")
+        }
+    }
+
+    override suspend fun write(
+        buffer: ReadBuffer,
+        deadline: Duration,
+    ): BytesWritten {
+        if (!open) throw SocketClosedException.General("WebSocket byte stream is closed")
+        val bytes = buffer.remaining()
+        withTimeout(deadline) { connection.send(WebSocketMessage.Binary(buffer)) }
+        return BytesWritten(bytes)
+    }
+
+    override suspend fun close() {
+        if (!open) return
+        open = false
+        connection.close()
+    }
+
+    private fun String.toUtf8Buffer(): ReadBuffer {
+        val buffer = config.bufferFactory.allocate(length * 4)
+        buffer.writeString(this, Charset.UTF8)
+        buffer.resetForRead()
+        return buffer
+    }
+}

--- a/websocket-tcp/src/commonTest/kotlin/com/ditchoom/websocket/tcp/WebSocketTransportTest.kt
+++ b/websocket-tcp/src/commonTest/kotlin/com/ditchoom/websocket/tcp/WebSocketTransportTest.kt
@@ -1,0 +1,247 @@
+package com.ditchoom.websocket.tcp
+
+import com.ditchoom.buffer.BufferFactory
+import com.ditchoom.buffer.ReadBuffer
+import com.ditchoom.buffer.flow.ByteStream
+import com.ditchoom.buffer.flow.BytesWritten
+import com.ditchoom.buffer.flow.ReadPolicy
+import com.ditchoom.buffer.flow.ReadResult
+import com.ditchoom.buffer.flow.WritePolicy
+import com.ditchoom.buffer.managed
+import com.ditchoom.socket.SocketClosedException
+import com.ditchoom.socket.TransportConfig
+import com.ditchoom.socket.transport.Transport
+import com.ditchoom.websocket.WebSocketException
+import com.ditchoom.websocket.handshake.computeAcceptKey
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Real-time runner: the codec's read loop runs on real dispatchers, so no virtual-time skipping. */
+private fun runRealTimeTest(block: suspend CoroutineScope.() -> Unit): TestResult =
+    runTest(timeout = 30.seconds) { withContext(Dispatchers.Default) { block() } }
+
+/**
+ * A scripted server-side [ByteStream]: auto-completes the RFC 6455 handshake on the first client
+ * write (with [handshakeStatus] controlling acceptance), captures every subsequent client frame,
+ * and lets tests enqueue unmasked server frames for the client to read. Mirrors the root module's
+ * MockWebSocketTransport, plus the handshake auto-responder this module's tests need.
+ */
+private class FakeServerByteStream : ByteStream {
+    private var open = true
+    private var handshakeDone = false
+    private val readQueue = Channel<ReadBuffer>(Channel.UNLIMITED)
+
+    /** Client frames captured after the handshake, as raw bytes. */
+    val frames = mutableListOf<ByteArray>()
+
+    /** HTTP status for the handshake response; 101 accepts, anything else rejects. */
+    var handshakeStatus = 101
+
+    fun enqueueServerFrame(
+        opcode: Int,
+        payload: ByteArray,
+    ) {
+        val frame = ByteArray(2 + payload.size)
+        frame[0] = (0x80 or opcode).toByte() // FIN + opcode; server frames are unmasked
+        frame[1] = payload.size.toByte() // tests keep payloads <= 125
+        payload.copyInto(frame, 2)
+        enqueueBytes(frame)
+    }
+
+    private fun enqueueBytes(bytes: ByteArray) {
+        val buffer = BufferFactory.managed().allocate(bytes.size)
+        buffer.writeBytes(bytes)
+        readQueue.trySend(buffer) // left in write mode; read() resets for read
+    }
+
+    override val isOpen: Boolean get() = open
+
+    override val readPolicy: ReadPolicy = ReadPolicy.Bounded(10.seconds)
+    override val writePolicy: WritePolicy = WritePolicy.Bounded(10.seconds)
+
+    override suspend fun read(deadline: Duration): ReadResult {
+        if (!open) return ReadResult.End
+        val buffer =
+            try {
+                withTimeout(deadline) { readQueue.receive() }
+            } catch (_: ClosedReceiveChannelException) {
+                return ReadResult.End
+            }
+        buffer.resetForRead()
+        return ReadResult.Data(buffer)
+    }
+
+    override suspend fun write(
+        buffer: ReadBuffer,
+        deadline: Duration,
+    ): BytesWritten {
+        val size = buffer.remaining()
+        val bytes = ByteArray(size) { buffer.readByte() }
+        if (!handshakeDone) {
+            handshakeDone = true
+            respondToHandshake(bytes.decodeToString())
+        } else {
+            frames.add(bytes)
+            // Ack a client Close so the codec's bounded close-handshake wait completes promptly.
+            if (size >= 1 && (bytes[0].toInt() and 0x0F) == 0x8) {
+                enqueueServerFrame(opcode = 0x8, payload = byteArrayOf(0x03, 0xE8.toByte()))
+            }
+        }
+        return BytesWritten(size)
+    }
+
+    private fun respondToHandshake(request: String) {
+        if (handshakeStatus != 101) {
+            enqueueBytes("HTTP/1.1 $handshakeStatus Nope\r\nContent-Length: 0\r\n\r\n".encodeToByteArray())
+            return
+        }
+        val clientKey =
+            request
+                .lineSequence()
+                .first { it.startsWith("Sec-WebSocket-Key:", ignoreCase = true) }
+                .substringAfter(":")
+                .trim()
+        val response =
+            "HTTP/1.1 101 Switching Protocols\r\n" +
+                "Upgrade: websocket\r\n" +
+                "Connection: Upgrade\r\n" +
+                "Sec-WebSocket-Accept: ${computeAcceptKey(clientKey)}\r\n" +
+                "\r\n"
+        enqueueBytes(response.encodeToByteArray())
+    }
+
+    override suspend fun close() {
+        open = false
+        readQueue.close()
+    }
+}
+
+private class FakeServerTransport : Transport {
+    val stream = FakeServerByteStream()
+
+    override suspend fun connect(
+        hostname: String,
+        port: Int,
+        config: TransportConfig,
+    ): ByteStream = stream
+}
+
+class WebSocketTransportTest {
+    private val config = TransportConfig(bufferFactory = BufferFactory.managed())
+
+    private suspend fun connectPipe(fake: FakeServerTransport): ByteStream =
+        WebSocketTransport(websocketEndpoint = "/pipe", underlying = fake)
+            .connect("localhost", 80, config)
+
+    private fun ReadResult.payloadBytes(): ByteArray {
+        val data = assertIs<ReadResult.Data>(this)
+        val buffer = data.buffer
+        return ByteArray(buffer.remaining()) { buffer.readByte() }
+    }
+
+    /** Decode a captured client frame: (opcode, unmasked payload). Client frames must be masked. */
+    private fun decodeClientFrame(frame: ByteArray): Pair<Int, ByteArray> {
+        val opcode = frame[0].toInt() and 0x0F
+        assertTrue((frame[1].toInt() and 0x80) != 0, "client frames must set the MASK bit")
+        val len = frame[1].toInt() and 0x7F
+        assertTrue(len <= 125, "test frames stay under the extended-length threshold")
+        val mask = frame.copyOfRange(2, 6)
+        val payload = ByteArray(len) { i -> (frame[6 + i].toInt() xor mask[i % 4].toInt()).toByte() }
+        return opcode to payload
+    }
+
+    @Test
+    fun binaryPayloadsRoundTripAsBytes() =
+        runRealTimeTest {
+            val fake = FakeServerTransport()
+            val pipe = connectPipe(fake)
+            assertTrue(pipe.isOpen)
+
+            fake.stream.enqueueServerFrame(opcode = 0x2, payload = byteArrayOf(1, 2, 3))
+            assertContentEquals(byteArrayOf(1, 2, 3), pipe.read(5.seconds).payloadBytes())
+
+            val out = BufferFactory.managed().allocate(3)
+            out.writeBytes(byteArrayOf(4, 5, 6))
+            out.resetForRead()
+            assertEquals(3, pipe.write(out, 5.seconds).count)
+
+            val (opcode, payload) = decodeClientFrame(fake.stream.frames.first())
+            assertEquals(0x2, opcode, "writes must go out as binary frames")
+            assertContentEquals(byteArrayOf(4, 5, 6), payload)
+            pipe.close()
+        }
+
+    @Test
+    fun pingFramesAreInvisibleToTheBytePipe() =
+        runRealTimeTest {
+            val fake = FakeServerTransport()
+            val pipe = connectPipe(fake)
+
+            fake.stream.enqueueServerFrame(opcode = 0x9, payload = byteArrayOf()) // ping
+            fake.stream.enqueueServerFrame(opcode = 0x2, payload = byteArrayOf(7))
+            assertContentEquals(byteArrayOf(7), pipe.read(5.seconds).payloadBytes())
+            pipe.close()
+        }
+
+    @Test
+    fun textFramesSurfaceAsUtf8Bytes() =
+        runRealTimeTest {
+            val fake = FakeServerTransport()
+            val pipe = connectPipe(fake)
+
+            fake.stream.enqueueServerFrame(opcode = 0x1, payload = "hi".encodeToByteArray())
+            assertContentEquals("hi".encodeToByteArray(), pipe.read(5.seconds).payloadBytes())
+            pipe.close()
+        }
+
+    @Test
+    fun serverCloseEndsTheStream() =
+        runRealTimeTest {
+            val fake = FakeServerTransport()
+            val pipe = connectPipe(fake)
+
+            fake.stream.enqueueServerFrame(opcode = 0x8, payload = byteArrayOf(0x03, 0xE8.toByte()))
+            assertIs<ReadResult.End>(pipe.read(5.seconds))
+            assertFalse(pipe.isOpen)
+
+            val buffer = BufferFactory.managed().allocate(1)
+            buffer.writeByte(1)
+            buffer.resetForRead()
+            assertFailsWith<SocketClosedException> { pipe.write(buffer, 1.seconds) }
+        }
+
+    @Test
+    fun rejectedHandshakeThrowsAndClosesTheUnderlyingStream() =
+        runRealTimeTest {
+            val fake = FakeServerTransport()
+            fake.stream.handshakeStatus = 404
+            assertFailsWith<WebSocketException> { connectPipe(fake) }
+            assertFalse(fake.stream.isOpen, "underlying transport must not leak on a failed upgrade")
+        }
+
+    @Test
+    fun closeRunsTheWebSocketCloseHandshake() =
+        runRealTimeTest {
+            val fake = FakeServerTransport()
+            val pipe = connectPipe(fake)
+            pipe.close()
+            assertFalse(pipe.isOpen)
+            val closeFrame = fake.stream.frames.firstOrNull { (it[0].toInt() and 0x0F) == 0x8 }
+            assertTrue(closeFrame != null, "close() must send an RFC 6455 Close frame, not just drop TCP")
+        }
+}


### PR DESCRIPTION
## Summary

The inverse of `connectWebSocket(transport: ByteStream, ...)`: a `WebSocketTransport` implementing socket's `com.ditchoom.socket.transport.Transport`, returning a `ByteStream` whose bytes ride binary WebSocket frames. This is the piece that lets WebSocket sit in socket's `FallbackTransport` chain (QUIC → WebTransport → TCP → **WebSocket**, DitchOoM/socket#201) as the universal floor — a protocol library binds to the returned `ByteStream` and never learns the bytes were framed.

Lives in `:websocket-tcp` (already has socket on its main classpath; dependency direction `websocket-tcp → :` unchanged, no cycles).

**Semantics:**
- `write()` = one binary frame; `read()` = next data payload (via the existing `BinaryPassThroughCodec`)
- Text frames surface as their UTF-8 bytes (a byte pipe has no message-type channel; dropping them would corrupt the stream)
- Ping/Pong invisible (library auto-pongs); Close/EOF → `ReadResult.End`; `close()` runs the full RFC 6455 close handshake
- Addressing is pre-set on the instance (endpoint path, subprotocols, compression) per the fallback RFC's resolved convention; `connect(host, port, config)` stays uniform, TLS from `TransportConfig.tls` (`wss` iff present)
- The internal frame loop uses an INFINITE read timeout — a quiet connection is not a dead one (the codec read loop treats a read timeout as a transport error and tears down); liveness belongs to the protocol riding the pipe, and each `ByteStream.read()/write()` is still bounded by its own per-call deadline
- Underlying transport injectable (defaults to `TcpTransport`), which is also the test seam

## Test plan

New `WebSocketTransportTest` (6 tests) with a scripted in-memory server (auto-completes the handshake via the public `computeAcceptKey`, captures + unmasks client frames): binary round-trip, ping invisibility, text-as-UTF-8-bytes, server-close → End + write throws, rejected upgrade (404) throws and doesn't leak the underlying stream, client `close()` sends a real Close frame. Green locally on `jvmTest`, `jsNodeTest`, and `macosArm64Test`; ktlint clean.