### PR TITLE
docs: rewrite README + Docusaurus to the real API (composability showcase)

### DIFF
--- a/.github/workflows/android_integration.yaml
+++ b/.github/workflows/android_integration.yaml
@@ -2,7 +2,10 @@ name: "Android Emulator Integration Test"
 on:
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - '.editorconfig'
     types:
       - synchronize
       - opened

--- a/.github/workflows/autobahn.yaml
+++ b/.github/workflows/autobahn.yaml
@@ -17,6 +17,7 @@ on:
   pull_request:
     paths-ignore:
       - '**/*.md'
+      - 'docs/**'
       - '.gitignore'
       - '.editorconfig'
   workflow_dispatch:

--- a/.github/workflows/review.yaml
+++ b/.github/workflows/review.yaml
@@ -2,7 +2,10 @@ name: "Build and Test"
 on:
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**/*.md'
+      - 'docs/**'
+      - '.gitignore'
+      - '.editorconfig'
     types:
       - synchronize
       - opened

--- a/README.md
+++ b/README.md
@@ -3,83 +3,204 @@ WebSocket
 
 See the [project website][docs] for documentation and APIs.
 
-WebSocket is a Kotlin Multiplatform library providing RFC 6455 compliant WebSocket client
-functionality with permessage-deflate compression (RFC 7692).
+**A composable, RFC 6455 WebSocket client for Kotlin Multiplatform — one API on JVM, Android, iOS, macOS, tvOS, watchOS, Linux, Node.js, and the browser, each delegating to the best native transport.**
 
-- **JVM/Android**: Built on `AsynchronousSocketChannel` (NIO2)
-- **iOS/macOS/tvOS/watchOS**: `NWConnection` via Network.framework
-- **Linux**: io_uring or epoll with direct zlib
-- **Node.js/Browser**: Native WebSocket API
-
-## Features
-
-- **Suspend-based API**: All I/O operations are coroutine-friendly suspend functions
-- **Flow-based messages**: Receive messages via `incomingMessages: Flow<WebSocketMessage>`
-- **Compression**: permessage-deflate with context takeover and custom window bits
-- **Zero-copy frame pipeline**: Direct buffer I/O with SIMD-optimized masking
-- **Full RFC 6455 compliance**: Passes all 517 Autobahn test cases
-
-## Installation
+WebSocket gives you a single `connect*` call that returns a typed `Connection<WebSocketMessage<B>>`: `send` and `receive` messages as a Kotlin `Flow`, decode binary frames into *your own types* with a pluggable codec, and — because it composes on top of [`com.ditchoom:socket`](https://github.com/DitchOoM/socket) — drop WebSocket in as the universal floor of a transport fallback chain.
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.ditchoom/websocket.svg)](https://central.sonatype.com/artifact/com.ditchoom/websocket)
 
+## Why this WebSocket?
+
+| Concern | Platform WebSocket / OkHttp / Ktor | This library |
+|---------|-----------------------------------|--------------|
+| Multiplatform | JVM-only (OkHttp), or a lowest-common-denominator API (Ktor) | One API; each platform delegates to its native transport (NIO2, Network.framework, io_uring, browser `WebSocket`) |
+| Binary messages | Hand off a `ByteArray`/`ByteBuffer`, parse it yourself | Supply a `Codec<B>` — binary frames arrive as **your decoded type** (`WebSocketMessage.Binary<B>`) |
+| Composition | An opaque client you can only talk WebSocket to | `WebSocketTransport` **is** a `socket` `Transport` — use it as a QUIC→WebTransport→TCP→**WebSocket** fallback rung |
+| Allocations | Copies through intermediate `ByteArray`s | Zero-copy `ReadBuffer`/`WriteBuffer` pipeline with SIMD-optimized masking |
+| Compression | Varies / unavailable | permessage-deflate (RFC 7692) everywhere, with context takeover + window bits where the platform allows |
+| Conformance | Varies | Passes all 517 [Autobahn](https://github.com/crossbario/autobahn-testsuite) test cases |
+
+## Installation
+
+Pick the module for how you want to connect — all pull in [`buffer`](https://github.com/DitchOoM/buffer) and (for the socket-backed modules) [`socket`](https://github.com/DitchOoM/socket) transitively.
+
 ```kotlin
 dependencies {
+    // Raw-socket platforms (JVM, Android, iOS/macOS, Linux, Node.js): TCP + TLS + WebSocket in one call
+    implementation("com.ditchoom:websocket-tcp:<latest-version>")
+
+    // Apple-only, backed by NSURLSessionWebSocketTask (system TLS/proxy/deflate, no socket dependency)
+    implementation("com.ditchoom:websocket-apple:<latest-version>")
+
+    // Core engine only — bring your own pre-connected ByteStream (advanced / browser lives here too)
     implementation("com.ditchoom:websocket:<latest-version>")
 }
 ```
 
 Find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.ditchoom/websocket).
 
-## Quick Example
+## Modules
+
+| Module | Entry point | Use when |
+|--------|-------------|----------|
+| `websocket` | `connectWebSocket(byteStream, options)` | You already have a connected `ByteStream`, or you're on the browser (`connectBrowserWebSocket`) |
+| `websocket-tcp` | `connectTcpWebSocket(options)` and `WebSocketTransport` | JVM/Android/Apple/Linux/Node.js over raw TCP+TLS; or composing WebSocket into a `socket` transport chain |
+| `websocket-apple` | `connectAppleNativeWebSocket(options)` | Apple platforms wanting the smallest binary and system-managed TLS/proxy |
+
+## Quick Start
 
 ```kotlin
+import com.ditchoom.websocket.WebSocketConnectionOptions
+import com.ditchoom.websocket.WebSocketMessage
+import com.ditchoom.websocket.use
+import com.ditchoom.websocket.tcp.connectTcpWebSocket
+import kotlinx.coroutines.flow.first
+
 val options = WebSocketConnectionOptions(
     name = "echo.websocket.org",
     port = 443,
-    tls = true,
+    tls = true,               // defaults to (port == 443)
+    websocketEndpoint = "/",
 )
-val client = WebSocketClient.allocate(options).connect()
 
-// Send a message
-client.write("Hello, WebSocket!")
+// `use` runs the block and closes the connection (RFC 6455 close handshake) in a finally.
+connectTcpWebSocket(options).use { ws ->
+    ws.send(WebSocketMessage.Text("Hello, WebSocket!"))
 
-// Receive messages
-client.incomingMessages.collect { message ->
+    val reply = ws.receive().first()          // receive() is a Flow<WebSocketMessage<Unit>>
+    println((reply as WebSocketMessage.Text).payload)
+}
+```
+
+`connect*` suspends until the socket is connected, the HTTP upgrade completes, and permessage-deflate is negotiated — the returned `Connection` is live. `send`/`receive` are **not** thread-safe; confine each to its own coroutine.
+
+### Messages
+
+`WebSocketMessage<B>` is a sealed interface — exhaustive `when`, no casting on the receive path:
+
+```kotlin
+ws.receive().collect { message ->
     when (message) {
-        is WebSocketMessage.Text -> println("Received: ${message.value}")
-        is WebSocketMessage.Binary -> println("Binary: ${message.value.remaining()} bytes")
+        is WebSocketMessage.Text   -> println("text: ${message.payload}")     // always a UTF-8 String
+        is WebSocketMessage.Binary -> handle(message.payload)                  // payload: B (your codec's type)
+        is WebSocketMessage.Ping   -> println("ping: ${message.appData}")      // auto-ponged for you
+        is WebSocketMessage.Pong   -> println("pong: ${message.appData}")
+        is WebSocketMessage.Close  -> println("close ${message.code}: ${message.reason}")
     }
 }
+```
 
-client.close()
+## Typed binary messages with codecs
+
+Text is always a `String` (RFC 6455 §5.6). **Binary frames run a `Codec<B>` you supply**, so `receive()` hands you your own decoded type instead of raw bytes — the generic threads through as `Connection<WebSocketMessage<B>>`.
+
+```kotlin
+// Given a Codec<SensorReading> (e.g. generated by buffer-codec):
+val ws: Connection<WebSocketMessage<SensorReading>> =
+    connectTcpWebSocket(options, binaryCodec = SensorReadingCodec)
+
+ws.send(WebSocketMessage.Binary(SensorReading(id = 7u, celsius = 21)))
+
+ws.receive().collect { msg ->
+    if (msg is WebSocketMessage.Binary) update(msg.payload)   // payload: SensorReading, already decoded
+}
+```
+
+Built-in codecs (`com.ditchoom.websocket.codecs`):
+
+| Codec | `B` | Behavior |
+|-------|-----|----------|
+| `EmptyCodec` | `Unit` | Default — discards binary payloads |
+| `BinaryPassThroughCodec` | `ReadBuffer` | Raw bytes copied into a consumer-owned buffer |
+| `RejectingCodec` | `Nothing` | Throws on any binary frame — fail loudly when binary isn't expected |
+
+Decode runs *after* fragment reassembly, and the wire buffer is freed before your value is emitted, so decoded values never alias library buffers. A custom codec can allocate from the same pool the wire path uses via the `WsBufferFactoryKey` injected into its `DecodeContext`.
+
+## WebSocket as a transport rung
+
+`connectWebSocket` *takes* a `ByteStream` and gives you WebSocket messages. `WebSocketTransport` is the inverse: it **is** a [`socket`](https://github.com/DitchOoM/socket) `Transport` that *returns* a `ByteStream` whose bytes ride binary WebSocket frames — so WebSocket can be the always-reachable floor of a fallback chain (QUIC → WebTransport → TCP → **WebSocket**) when hostile middleboxes block everything but `:443`.
+
+```kotlin
+import com.ditchoom.websocket.tcp.WebSocketTransport
+
+val transport = WebSocketTransport(
+    websocketEndpoint = "/tunnel",
+    underlying = TcpTransport(),      // the WS handshake rides this transport
+)
+
+// Slots into any socket API that takes a Transport (e.g. a FallbackTransport chain):
+val stream: ByteStream = transport.connect(host, port, config)
+stream.write(payload)                 // one binary WebSocket frame per write
 ```
 
 ## Compression
 
-Request permessage-deflate compression for reduced bandwidth:
+Request permessage-deflate (RFC 7692) — negotiated during the handshake, transparent thereafter:
 
 ```kotlin
 val options = WebSocketConnectionOptions(
     name = "example.com",
     requestCompression = true,
     compressionOptions = CompressionOptions(
-        clientNoContextTakeover = false, // maintain LZ77 window across messages
+        clientNoContextTakeover = false,  // keep the LZ77 window across messages (better ratio)
         serverNoContextTakeover = false,
+        clientMaxWindowBits = 15,         // 0 = don't request (platform default)
     ),
 )
 ```
 
+## Error handling
+
+`connect*` and `send` throw the sealed `WebSocketException`:
+
+```kotlin
+try {
+    connectTcpWebSocket(options).use { ws -> /* ... */ }
+} catch (e: WebSocketException.HandshakeRejected) {
+    println("server rejected the upgrade: HTTP ${e.statusCode}")
+} catch (e: WebSocketException.TransportFailed) {
+    println("network/TLS failure: ${e.cause?.message}")
+} catch (e: WebSocketException.ProtocolViolation) {
+    println("peer broke RFC 6455: ${e.message}")
+} catch (e: WebSocketException.ConnectionClosed) {
+    println("closed: code=${e.code} reason=${e.reason}")
+}
+```
+
+## Choosing an entry point
+
+| You have… | Call | Module |
+|-----------|------|--------|
+| A host + port, on JVM/Android/Apple/Linux/Node.js | `connectTcpWebSocket(options)` | `websocket-tcp` |
+| An Apple app wanting system-managed TLS/proxy | `connectAppleNativeWebSocket(options)` | `websocket-apple` |
+| Browser JS | `connectBrowserWebSocket(options)` | `websocket` (jsMain) |
+| A pre-connected `ByteStream` (custom transport, QUIC, test double) | `connectWebSocket(stream, options)` | `websocket` |
+
 ## Platform Support
 
-| Platform | Implementation | Compression |
-|----------|---------------|-------------|
-| JVM 1.8+ | NIO2 AsyncSocketChannel | Context takeover, max_window_bits=15 |
-| Android | Same as JVM | Same as JVM |
-| iOS/macOS/tvOS/watchOS | NWConnection | Context takeover |
-| Linux x64/ARM64 | io_uring / epoll | Context takeover + custom window bits |
-| Node.js | Native WebSocket | No context takeover |
-| Browser | Native WebSocket | Handled by browser |
+| Platform | Transport | Compression |
+|----------|-----------|-------------|
+| JVM 1.8+ / Android | NIO2 `AsynchronousSocketChannel` | context takeover, `max_window_bits=15` |
+| iOS / macOS / tvOS / watchOS | `NWConnection` (Network.framework) or `NSURLSessionWebSocketTask` | context takeover |
+| Linux x64 / ARM64 | io_uring or epoll, direct zlib | context takeover + custom window bits |
+| Node.js | raw socket, RFC 6455 engine | no context takeover |
+| Browser | native `WebSocket` | handled by the browser |
+
+## Part of the DitchOoM stack
+
+WebSocket sits on top of [`socket`](https://github.com/DitchOoM/socket) (TCP + TLS + transport fallback) and [`buffer`](https://github.com/DitchOoM/buffer) (zero-copy `ReadBuffer`/`WriteBuffer` + codecs), and composes both ways — consuming a `ByteStream` to speak WebSocket, or exposing one as a fallback `Transport`.
+
+```
+┌─────────────────────────────┐
+│  Your app / protocol        │
+├─────────────────────────────┤
+│  websocket (+ your Codec<B>) │  ← com.ditchoom:websocket(-tcp / -apple)
+├─────────────────────────────┤
+│  socket (TCP + TLS + fallback)  ← com.ditchoom:socket   (WebSocketTransport plugs in here)
+├─────────────────────────────┤
+│  buffer (+ buffer-codec)    │  ← com.ditchoom:buffer
+└─────────────────────────────┘
+```
 
 ## License
 

--- a/docs/docs/core-concepts/connection-lifecycle.md
+++ b/docs/docs/core-concepts/connection-lifecycle.md
@@ -6,57 +6,81 @@ sidebar_position: 1
 
 # Connection Lifecycle
 
-## States
+A `Connection<WebSocketMessage<B>>` has a simple, explicit lifecycle: you `connect`, `send`/`receive`
+while it's live, and `close`. There is no separate "state" object on the base connection — the state
+*is* whether `connect*` returned, whether `receive()` is still emitting, and whether `close()` has
+run. (For an observable state machine across reconnects, see [Reconnection](reconnection.md).)
 
-A WebSocket connection moves through these states, exposed via `connectionState: StateFlow<ConnectionState>`:
+## Connecting
 
-```
-Initialized ──> Connecting ──> Connected ──> Disconnected
-                    │                            ▲
-                    └────────────────────────────┘
-                         (connection failed)
-```
+`connect*` suspends and only returns once the connection is fully established:
 
-- **Initialized** - Client created, no connection attempt yet
-- **Connecting** - TCP/TLS handshake and HTTP upgrade in progress
-- **Connected** - WebSocket connection established, ready for messages
-- **Disconnected** - Connection ended (normal close, error, or server-initiated)
+1. TCP connect (and TLS handshake, when `tls`)
+2. RFC 6455 HTTP `Upgrade` request + `101 Switching Protocols` response, validated
+3. permessage-deflate negotiated (if `requestCompression`)
 
-## Connection Flow
-
-1. `WebSocketClient.allocate(options)` creates the client in `Initialized` state
-2. `connect()` transitions to `Connecting`, performs TCP/TLS + HTTP upgrade
-3. On success, transitions to `Connected` and starts the read loop
-4. Messages flow through `incomingMessages` / `incomingTextMessages` / `incomingBinaryMessages`
-5. `close()` sends a close frame, waits for the read loop to exit, then transitions to `Disconnected`
-
-## Close Behavior
-
-When `close()` is called:
-
-1. Sends a WebSocket close frame (code 1000, "Client closing") if still connected
-2. Clears the frame writer to prevent further writes
-3. Closes compression resources
-4. Closes the underlying socket (unblocks any pending read)
-5. Waits for the read loop to finish cleanup (releasing buffers)
-
-The close is deterministic - no timeouts. The socket close unblocks the read loop, which catches the I/O exception and exits naturally.
-
-## Server-Initiated Close
-
-When the server sends a close frame:
-
-1. The read loop receives and processes the close frame
-2. `connectionState` transitions to `Disconnected` with the server's close code and reason
-3. The read loop exits, releasing resources
-4. Subsequent `close()` calls are a no-op (already disconnected)
-
-## Awaiting Connection
+If any step fails it throws a [`WebSocketException`](error-handling.md); it never returns a
+half-open connection. On success the read loop is already running.
 
 ```kotlin
-// Wait for the connection to be established
-client.connect()
-
-// Or reactively observe state changes
-client.connectionState.first { it is ConnectionState.Connected }
+val ws = connectTcpWebSocket(options)   // live on return
 ```
+
+## Sending & receiving
+
+While live, `send(message)` writes a frame and `receive()` emits inbound messages as a `Flow`:
+
+```kotlin
+ws.send(WebSocketMessage.Text("hello"))
+
+ws.receive().collect { message -> /* ... */ }   // suspends until the connection closes
+```
+
+Ping frames are answered with a Pong automatically; you still see them in `receive()` if you want to
+observe them. `send`/`receive` are not thread-safe — confine each to its own coroutine.
+
+## Closing
+
+`close()` performs the RFC 6455 **close handshake**:
+
+1. Sends a Close frame (code `1000` by default) if still connected
+2. Waits — bounded by a 5-second timeout — for the peer's Close frame or EOF, so in-flight writes
+   drain instead of being cut off
+3. Tears down the transport, cancels the read loop, and releases pooled buffers
+
+The `receive()` flow **completes** when the connection closes, so a `collect` naturally ends. Calling
+`close()` again is a no-op.
+
+Use the `use { }` extension to close deterministically even on exceptions — the idiomatic pattern:
+
+```kotlin
+connectTcpWebSocket(options).use { ws ->
+    ws.send(WebSocketMessage.Text("hello"))
+    val reply = ws.receive().first()
+    // ... close() runs here, in a finally
+}
+```
+
+## Server-initiated close
+
+When the peer closes:
+
+1. A `WebSocketMessage.Close(code, reason)` is emitted from `receive()` (the last message)
+2. The `receive()` flow completes
+3. The connection is torn down; a later `close()` is a no-op
+
+```kotlin
+ws.receive().collect { message ->
+    if (message is WebSocketMessage.Close) {
+        println("server closed: ${message.code} ${message.reason}")
+    }
+}
+// ...flow completed — the connection is gone
+```
+
+## Observing state across reconnects
+
+The base connection is single-shot: once closed, it's done. To observe `Connecting` / `Connected` /
+`Disconnected` transitions across automatic reconnects, wrap it in `socket`'s
+`ReconnectingConnection`, which exposes a `state: StateFlow<ConnectionState>`. See
+[Reconnection](reconnection.md).

--- a/docs/docs/core-concepts/error-handling.md
+++ b/docs/docs/core-concepts/error-handling.md
@@ -6,101 +6,92 @@ sidebar_position: 2
 
 # Error Handling
 
-## Exception Hierarchy
-
-All WebSocket-specific errors are subtypes of the sealed `WebSocketException` class:
+All WebSocket-specific failures are subtypes of the sealed `WebSocketException`, so you can catch at
+exactly the granularity you need without reaching for socket-level types:
 
 ```
 WebSocketException (sealed)
-├── TransportFailed      - TCP/TLS failure
-├── HandshakeRejected    - HTTP upgrade rejected
-├── ProtocolViolation    - RFC 6455 violation
-└── ConnectionClosed     - WebSocket close with code/reason
+├── TransportFailed      - TCP/TLS failure (original socket exception in .cause)
+├── HandshakeRejected    - HTTP upgrade rejected (.statusCode)
+├── ProtocolViolation    - peer broke RFC 6455
+└── ConnectionClosed     - closed with a WebSocket code/reason (.code, .reason)
 ```
 
-This lets you catch errors at the right granularity without importing socket-level types:
+`connect*` and `send` are the throwing surfaces:
 
 ```kotlin
 try {
-    client.connect()
-    // ... use client ...
+    connectTcpWebSocket(options).use { ws ->
+        ws.send(WebSocketMessage.Text("hello"))
+        ws.receive().collect { /* ... */ }
+    }
 } catch (e: WebSocketException.TransportFailed) {
-    // Network issue: DNS failure, connection refused, TLS error
-    // Original socket exception available in e.cause
+    // Network/TLS: DNS failure, connection refused, certificate error, timeout.
+    // The underlying socket exception is in e.cause.
 } catch (e: WebSocketException.HandshakeRejected) {
-    // Server returned non-101 status or invalid handshake
-    // HTTP status code available in e.statusCode
+    // Server answered the upgrade with a non-101 status or an invalid handshake.
 } catch (e: WebSocketException) {
-    // Catch-all for any WebSocket error
+    // Catch-all for any WebSocket error.
 }
 ```
 
 ## TransportFailed
 
-Wraps socket-level errors (DNS, TCP, TLS). The original `SocketException` is in `cause`:
+Wraps a socket-level failure (DNS, TCP, TLS). Inspect `e.cause` for the concrete `socket` exception:
 
 ```kotlin
 catch (e: WebSocketException.TransportFailed) {
-    when (val cause = e.cause) {
-        is SocketUnknownHostException -> // DNS resolution failed
-        is SocketConnectionException.Refused -> // Server not listening
-        is SSLHandshakeFailedException -> // TLS certificate error
-        is SocketTimeoutException -> // Connection timed out
+    when (e.cause) {
+        // e.g. SocketUnknownHostException     -> DNS resolution failed
+        // e.g. SSLHandshakeFailedException    -> TLS certificate/handshake error
+        // e.g. a connection-refused / timeout -> server not listening / slow network
+        else -> log(e.cause)
     }
 }
 ```
 
 ## HandshakeRejected
 
-The server responded to the HTTP upgrade but the response was invalid:
+The server responded to the HTTP upgrade, but not with a valid `101`. `statusCode` is the HTTP
+status when there was one, or `null` for a malformed handshake (bad `Sec-WebSocket-Accept`, missing
+headers):
 
 ```kotlin
 catch (e: WebSocketException.HandshakeRejected) {
     when (e.statusCode) {
-        401 -> // Authentication required
-        403 -> // Forbidden
-        404 -> // Endpoint not found
-        null -> // Invalid handshake (wrong accept key, missing headers)
+        401 -> // authentication required
+        403 -> // forbidden
+        404 -> // endpoint not found
+        null -> // invalid handshake
+        else -> // other non-101 response
     }
 }
 ```
 
 ## ProtocolViolation
 
-The server sent data that violates RFC 6455:
-
-- Invalid UTF-8 in a text frame
-- Reserved opcode used
-- Fragmentation protocol violation
-- Control frame too large (> 125 bytes)
+The peer sent something that violates RFC 6455 — invalid UTF-8 in a text frame, a reserved opcode, a
+fragmentation violation, or an oversized control frame (> 125 bytes). Retrying won't help; it's an
+implementation mismatch.
 
 ## ConnectionClosed
 
-The connection was closed with a WebSocket close code:
+Thrown by `send` when the connection is already closed. It carries the WebSocket close `code` and
+`reason` when the peer initiated the close:
 
 ```kotlin
 catch (e: WebSocketException.ConnectionClosed) {
     when (e.code?.toInt()) {
-        1000 -> // Normal closure
-        1001 -> // Going away
-        1002 -> // Protocol error
-        1003 -> // Unsupported data
-        1006 -> // Abnormal closure (no close frame)
-        1011 -> // Server error
+        1000 -> // normal closure
+        1001 -> // going away
+        1002 -> // protocol error
+        1006 -> // abnormal closure (no close frame)
+        1011 -> // server error
+        else -> // other / null
     }
 }
 ```
 
-## Disconnected State
-
-The `ConnectionState.Disconnected` state carries the same error information:
-
-```kotlin
-client.connectionState.collect { state ->
-    if (state is ConnectionState.Disconnected) {
-        val error = state.t  // Throwable? (often a WebSocketException)
-        val code = state.code  // UShort? (WebSocket close code)
-        val reason = state.reason  // String? (close reason)
-    }
-}
-```
+You also observe a graceful peer close as a `WebSocketMessage.Close(code, reason)` emitted from
+`receive()` before the flow completes — see [Connection Lifecycle](connection-lifecycle.md). Use the
+exception path for `send`-after-close and the message path for orderly shutdown.

--- a/docs/docs/core-concepts/reconnection.md
+++ b/docs/docs/core-concepts/reconnection.md
@@ -6,60 +6,79 @@ sidebar_position: 4
 
 # Reconnection
 
-## ReconnectingWebSocketClient
-
-Wraps `WebSocketClient` with automatic reconnection logic:
+There's no WebSocket-specific reconnecting client — and there doesn't need to be. Reconnection lives
+in the `socket` library as **`ReconnectingConnection<T>`**, which wraps *any* `suspend () -> Connection<T>`
+with network-aware backoff. Because a WebSocket connection is just a `Connection<WebSocketMessage<B>>`,
+it composes directly:
 
 ```kotlin
-val client = ReconnectingWebSocketClient(
-    connectionOptions = options,
-    classifier = WebSocketReconnectionClassifier(),
+import com.ditchoom.socket.transport.ReconnectingConnection
+import com.ditchoom.socket.DefaultReconnectionClassifier
+
+val conn = ReconnectingConnection(
+    connect = { connectTcpWebSocket(options) },        // re-invoked on each reconnect
+    classifier = DefaultReconnectionClassifier(),
 )
 
-client.connect()
-
-// Messages from all connections are merged into a single flow
-client.incomingTextMessages.collect { text ->
-    processMessage(text)
-}
-```
-
-On disconnection, the classifier decides whether to retry. If yes, a fresh `WebSocketClient` is created and connected. All message flows are merged across reconnections.
-
-## Reconnection Classifier
-
-`WebSocketReconnectionClassifier` makes intelligent retry decisions based on the error type:
-
-| Error | Decision | Rationale |
-|-------|----------|-----------|
-| `HandshakeRejected` | Give up | Server explicitly rejected; retrying won't help |
-| `ProtocolViolation` | Give up | Implementation mismatch; retrying won't help |
-| `ConnectionClosed(1000)` | Give up | Normal closure; intentional disconnect |
-| `ConnectionClosed(other)` | Retry | Abnormal close; may be transient |
-| `TransportFailed` | Delegate | Depends on underlying socket error |
-| DNS failure | Give up | Host doesn't exist |
-| TLS certificate error | Give up | Security configuration issue |
-| Connection refused | Retry with backoff | Server may be restarting |
-| Timeout | Retry with backoff | Network congestion |
-
-## Custom Classifier
-
-Implement `ReconnectionClassifier` for custom retry logic:
-
-```kotlin
-class MyClassifier : ReconnectionClassifier {
-    override suspend fun classify(error: Throwable): ReconnectionDecision {
-        return when {
-            isBusinessHours() -> RetryWithBackoff(delay = 5.seconds)
-            else -> GiveUp
-        }
+// ReconnectingConnection is itself a Connection<T> — same send/receive/close API.
+// A single receive() flow survives reconnects; messages from every underlying
+// connection are merged into it.
+conn.receive().collect { message ->
+    when (message) {
+        is WebSocketMessage.Text -> handle(message.payload)
+        else -> {}
     }
+}
+```
 
-    fun reset() { /* Reset backoff state */ }
+Your `connect` lambda is the reconnection unit: run *everything* a fresh session needs inside it
+(connect, and any app-level handshake such as an MQTT `CONNECT`), so each reconnect re-establishes a
+fully-ready connection.
+
+## Network-aware backoff
+
+`ReconnectingConnection` doesn't just sleep between attempts. Via its `monitorFactory` (default
+`NetworkMonitor.default()`, the platform's best reactive monitor) it:
+
+- **resets backoff** when the network becomes available again, reconnecting immediately instead of
+  waiting out the current delay;
+- **races the backoff against path changes** — Wi-Fi returning, cellular taking over, a captive
+  portal clearing — abandoning the remaining delay to retry at once.
+
+Pass `monitorFactory = { NetworkMonitor.AlwaysAvailable }` to opt out and get a plain backoff. It
+also exposes observable state:
+
+```kotlin
+conn.state.collect { println(it) }                 // StateFlow<ConnectionState>
+conn.lastMessageReceived.value                      // timestamp of the last decoded message
+```
+
+## Deciding when to retry
+
+A `ReconnectionClassifier` maps the failure to a `ReconnectDecision`: `RetryAfter(delay)` or
+`GiveUp`. `DefaultReconnectionClassifier()` gives up on permanent failures (host doesn't exist,
+normal close) and retries transient ones with backoff. It's a `fun interface`, so a custom policy is
+a lambda:
+
+```kotlin
+import com.ditchoom.socket.ReconnectionClassifier
+import com.ditchoom.socket.ReconnectDecision
+import kotlin.time.Duration.Companion.seconds
+
+val classifier = ReconnectionClassifier { error ->
+    when (error) {
+        is WebSocketException.HandshakeRejected -> ReconnectDecision.GiveUp       // server said no
+        is WebSocketException.ProtocolViolation -> ReconnectDecision.GiveUp       // implementation mismatch
+        else                                    -> ReconnectDecision.RetryAfter(5.seconds)
+    }
 }
 
-val client = ReconnectingWebSocketClient(
-    connectionOptions = options,
-    classifier = MyClassifier(),
+val conn = ReconnectingConnection(
+    connect = { connectTcpWebSocket(options) },
+    classifier = classifier,
 )
 ```
+
+See the [socket documentation](https://ditchoom.github.io/socket/) for the full `ReconnectingConnection`
+surface, including the `liveness` seam that tears down a half-open connection on a path change so
+reconnection starts promptly instead of waiting for the OS TCP timeout.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -6,158 +6,168 @@ sidebar_position: 2
 
 # Getting Started
 
-## Basic Usage
+Every entry point returns a `Connection<WebSocketMessage<B>>` — a small interface with three
+members: `send`, `receive` (a `Flow`), and `close`. You pick how to connect based on your platform;
+the message API is identical everywhere.
 
-Connect to a WebSocket server, send a message, and receive the echo:
-
-```kotlin
-val options = WebSocketConnectionOptions(
-    name = "echo.websocket.org",
-    port = 443,
-    tls = true,
-    websocketEndpoint = "/.ws",
-)
-
-val client = WebSocketClient.allocate(options)
-client.connect()
-
-// Send a text message
-client.write("Hello, WebSocket!")
-
-// Receive the echo
-val echo = client.incomingTextMessages.first()
-println("Received: $echo")
-
-client.close()
-```
-
-## Connection Options
-
-Configure the connection with `WebSocketConnectionOptions`:
+## Install
 
 ```kotlin
-val options = WebSocketConnectionOptions(
-    name = "example.com",           // Hostname
-    port = 443,                     // Port (443 enables TLS by default)
-    tls = true,                     // Enable TLS (or use TlsConfig for fine-grained control)
-    websocketEndpoint = "/ws",      // WebSocket path
-    protocols = listOf("mqtt"),     // Subprotocol negotiation
-    connectionTimeout = 10.seconds, // Connection timeout
-    readTimeout = 10.seconds,       // Read timeout
-    writeTimeout = 10.seconds,      // Write timeout
-    requestCompression = true,      // Enable permessage-deflate
-)
-```
-
-## Receiving Messages
-
-Messages are exposed as Kotlin Flows. Use typed flows to avoid casting:
-
-```kotlin
-val client = WebSocketClient.allocate(options)
-client.connect()
-
-// Option 1: All message types
-client.incomingMessages.collect { message ->
-    when (message) {
-        is WebSocketMessage.Text -> println("Text: ${message.value}")
-        is WebSocketMessage.Binary -> println("Binary: ${message.value.remaining()} bytes")
-        is WebSocketMessage.Ping -> println("Ping received")
-        is WebSocketMessage.Pong -> println("Pong received")
-        is WebSocketMessage.Close -> println("Close: ${message.code} ${message.reason}")
-    }
-}
-
-// Option 2: Text messages only (more efficient)
-client.incomingTextMessages.collect { text ->
-    println("Text: $text")
-}
-
-// Option 3: Binary messages only
-client.incomingBinaryMessages.collect { buffer ->
-    println("Binary: ${buffer.remaining()} bytes")
-}
-```
-
-## Connection State
-
-Track connection lifecycle with `connectionState`:
-
-```kotlin
-client.connectionState.collect { state ->
-    when (state) {
-        ConnectionState.Initialized -> println("Ready to connect")
-        ConnectionState.Connecting -> println("Connecting...")
-        ConnectionState.Connected -> println("Connected!")
-        is ConnectionState.Disconnected -> {
-            println("Disconnected: ${state.reason}")
-            state.t?.let { println("Error: ${it.message}") }
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            // TCP + TLS + WebSocket for JVM, Android, Apple, Linux, and Node.js:
+            implementation("com.ditchoom:websocket-tcp:<latest-version>")
         }
     }
 }
 ```
 
-## Error Handling
+See [Choosing an entry point](#choosing-an-entry-point) for the browser and Apple-native modules.
 
-Catch `WebSocketException` subtypes for specific error handling:
+## Connect, send, receive
+
+```kotlin
+import com.ditchoom.websocket.WebSocketConnectionOptions
+import com.ditchoom.websocket.WebSocketMessage
+import com.ditchoom.websocket.use
+import com.ditchoom.websocket.tcp.connectTcpWebSocket
+import kotlinx.coroutines.flow.first
+
+val options = WebSocketConnectionOptions(
+    name = "echo.websocket.org",
+    port = 443,
+    tls = true,                 // defaults to (port == 443)
+    websocketEndpoint = "/",
+)
+
+connectTcpWebSocket(options).use { ws ->
+    ws.send(WebSocketMessage.Text("Hello, WebSocket!"))
+
+    val reply = ws.receive().first()
+    println((reply as WebSocketMessage.Text).payload)
+}
+```
+
+`connectTcpWebSocket` suspends until the TCP/TLS connection is up, the HTTP upgrade has completed,
+and permessage-deflate has been negotiated — the returned connection is live. `use { }` runs your
+block and then `close()`s the connection (the RFC 6455 close handshake) in a `finally`.
+
+> `send` and `receive` are **not** thread-safe. Send from one coroutine and collect `receive()` in
+> another; don't share a single connection across concurrent senders.
+
+## Receiving messages
+
+`receive()` is a `Flow<WebSocketMessage<B>>`. `WebSocketMessage` is a sealed interface, so a `when`
+is exhaustive with no casting:
+
+```kotlin
+ws.receive().collect { message ->
+    when (message) {
+        is WebSocketMessage.Text   -> println("text: ${message.payload}")   // always a UTF-8 String
+        is WebSocketMessage.Binary -> handle(message.payload)               // payload: B (see Codecs)
+        is WebSocketMessage.Ping   -> println("ping: ${message.appData}")   // auto-ponged for you
+        is WebSocketMessage.Pong   -> println("pong: ${message.appData}")
+        is WebSocketMessage.Close  -> println("close ${message.code}: ${message.reason}")
+    }
+}
+```
+
+The flow completes when the connection closes (peer Close frame, EOF, or your own `close()`), so a
+`collect` on the connection is a natural read loop.
+
+## Sending messages
+
+`send` takes the same sealed `WebSocketMessage`:
+
+```kotlin
+ws.send(WebSocketMessage.Text("a text frame"))
+ws.send(WebSocketMessage.Ping("keepalive"))              // appData ≤ 125 bytes
+ws.send(WebSocketMessage.Close(code = 1000u, reason = "done"))
+```
+
+Binary sends carry your codec's type — see [Typed binary messages](#typed-binary-messages). With the
+default `EmptyCodec` the binary payload type is `Unit`, so use a codec (or `BinaryPassThroughCodec`)
+when you need to send bytes.
+
+## Connection options
+
+`WebSocketConnectionOptions` is a `data class`:
+
+```kotlin
+val options = WebSocketConnectionOptions(
+    name = "example.com",             // host (required)
+    port = 443,                       // default 443
+    tls = true,                       // default: port == 443
+    websocketEndpoint = "/ws",        // request path, default "/"
+    protocols = listOf("mqtt"),       // Sec-WebSocket-Protocol, default empty
+    connectionTimeout = 15.seconds,   // default 15s
+    readTimeout = 15.seconds,         // default: connectionTimeout
+    writeTimeout = 15.seconds,        // default: connectionTimeout
+    requestCompression = true,        // permessage-deflate, default false
+    // compressionOptions = CompressionOptions(...),  // see Compression
+    // bufferFactory = BufferFactory.deterministic(), // default; see below
+)
+```
+
+`bufferFactory` defaults to `BufferFactory.deterministic()` (off-heap, zero-copy, deterministic
+cleanup). If you pass a shared `BufferPool`, it must be `ThreadingMode.MultiThreaded` or the connect
+fails fast with `IllegalArgumentException`.
+
+## Typed binary messages
+
+Text frames are always `String`. Binary frames run a `com.ditchoom.buffer.codec.Codec<B>` that you
+supply, so `receive()` hands you your own decoded type instead of raw bytes:
+
+```kotlin
+val ws: Connection<WebSocketMessage<SensorReading>> =
+    connectTcpWebSocket(options, binaryCodec = SensorReadingCodec)
+
+ws.send(WebSocketMessage.Binary(SensorReading(id = 7u, celsius = 21)))
+
+ws.receive().collect { msg ->
+    if (msg is WebSocketMessage.Binary) update(msg.payload)   // payload: SensorReading
+}
+```
+
+See [Typed messages with codecs](recipes/typed-messages-with-codecs.md) for the built-in codecs and
+how to write your own.
+
+## Error handling
+
+`connect*` and `send` throw the sealed `WebSocketException`:
 
 ```kotlin
 try {
-    client.connect()
+    connectTcpWebSocket(options).use { ws -> /* ... */ }
 } catch (e: WebSocketException.HandshakeRejected) {
-    println("Server rejected: ${e.statusCode}")
+    println("upgrade rejected: HTTP ${e.statusCode}")
 } catch (e: WebSocketException.TransportFailed) {
-    println("Network error: ${e.cause.message}")
+    println("network/TLS failure: ${e.cause?.message}")
 } catch (e: WebSocketException.ProtocolViolation) {
-    println("Protocol error: ${e.message}")
+    println("peer broke RFC 6455: ${e.message}")
 } catch (e: WebSocketException.ConnectionClosed) {
-    println("Closed: code=${e.code}, reason=${e.reason}")
+    println("closed: code=${e.code} reason=${e.reason}")
 }
 ```
 
-## Auto-Reconnection
+See [Error handling](core-concepts/error-handling.md) for the full hierarchy.
 
-Use `ReconnectingWebSocketClient` for automatic reconnection with backoff:
+## Auto-reconnection
 
-```kotlin
-val client = ReconnectingWebSocketClient(
-    connectionOptions = options,
-    classifier = WebSocketReconnectionClassifier(),
-)
+Reconnection lives in the `socket` library as `ReconnectingConnection<T>`, which wraps *any*
+`Connection<T>` — including a WebSocket one — with network-aware backoff. See
+[Reconnection](core-concepts/reconnection.md).
 
-client.connect() // Starts reconnection loop
+## Choosing an entry point
 
-// Messages from all connections are merged into a single flow
-client.incomingTextMessages.collect { text ->
-    println("Received: $text")
-}
-```
+| You have… | Call | Module |
+|-----------|------|--------|
+| A host + port, on JVM/Android/Apple/Linux/Node.js | `connectTcpWebSocket(options)` | `websocket-tcp` |
+| An Apple app wanting system-managed TLS/proxy | `connectAppleNativeWebSocket(options)` | `websocket-apple` |
+| Browser JS | `connectBrowserWebSocket(options)` | `websocket` (jsMain) |
+| A pre-connected `ByteStream` (custom transport, test double) | `connectWebSocket(stream, options)` | `websocket` |
 
-The classifier determines retry behavior:
-- **Give up** on: handshake rejection, protocol violations, normal close (code 1000)
-- **Retry with backoff** on: transport failures, abnormal disconnects
-- **Never retry** on: DNS failures, TLS certificate errors
-
-## Sending Binary Data
-
-```kotlin
-val buffer = BufferFactory.allocate(1024)
-buffer.writeString("binary payload", Charset.UTF8)
-buffer.resetForRead()
-
-client.write(buffer)
-```
-
-## Ping/Pong
-
-```kotlin
-if (client.isPingSupported()) {
-    client.ping() // Empty ping
-    client.ping(payloadBuffer) // Ping with payload
-}
-
-// Pong responses arrive in incomingMessages
-client.incomingMessages.filterIsInstance<WebSocketMessage.Pong>().collect { pong ->
-    println("Pong: ${pong.value.remaining()} bytes")
-}
-```
+All four have the same shape — an optional `binaryCodec: Codec<B>` and `parentScope: CoroutineScope?`
+— and all return `Connection<WebSocketMessage<B>>`, so the rest of your code is identical regardless
+of platform.

--- a/docs/docs/guides/mqtt-over-websocket.md
+++ b/docs/docs/guides/mqtt-over-websocket.md
@@ -6,51 +6,68 @@ sidebar_position: 1
 
 # MQTT over WebSocket
 
-The WebSocket library powers the transport layer for [`com.ditchoom:mqtt-client`](https://github.com/DitchOoM/mqtt), enabling MQTT communication over WebSocket connections.
+MQTT brokers commonly accept connections over WebSocket: MQTT control packets ride **binary**
+WebSocket frames, negotiated with the `mqtt` subprotocol. Two ways to wire it up.
 
-## Basic Setup
+## As a byte transport (recommended)
+
+An MQTT client just needs a bidirectional byte stream. `WebSocketTransport` (from `websocket-tcp`)
+*is* a `socket` `Transport`, so a socket-based MQTT client can run over WebSocket by swapping its
+transport — no MQTT-specific WebSocket glue:
 
 ```kotlin
-val wsOptions = WebSocketConnectionOptions(
-    name = "broker.example.com",
-    port = 80,
+import com.ditchoom.websocket.tcp.WebSocketTransport
+
+val transport = WebSocketTransport(
     websocketEndpoint = "/mqtt",
-    protocols = listOf("mqtt"),  // MQTT subprotocol
+    protocols = listOf("mqtt"),         // Sec-WebSocket-Protocol
+    underlying = TcpTransport(),         // TLS follows config.tls
 )
 
-val client = WebSocketClient.allocate(wsOptions)
-client.connect()
-
-// Binary frames carry MQTT packets
-client.incomingBinaryMessages.collect { buffer ->
-    val mqttPacket = decodeMqttPacket(buffer)
-    handlePacket(mqttPacket)
-}
+// Hand `transport` to a socket-based client (e.g. com.ditchoom:mqtt-client).
+// Each write() becomes one binary WebSocket frame; each read() yields the next payload.
 ```
 
-## With TLS
+This is how [`com.ditchoom:mqtt-client`](https://github.com/DitchOoM/mqtt) speaks MQTT over WebSocket:
+the same packet codec, a different transport rung. See
+[WebSocket as a transport](../recipes/websocket-as-transport.md).
+
+## Directly, with a binary codec
+
+If you want to handle frames yourself, connect with `BinaryPassThroughCodec` so binary frames arrive
+as raw `ReadBuffer`s you can decode into MQTT packets:
 
 ```kotlin
-val wsOptions = WebSocketConnectionOptions(
+import com.ditchoom.websocket.codecs.BinaryPassThroughCodec
+
+val options = WebSocketConnectionOptions(
     name = "broker.example.com",
     port = 443,
     tls = true,
     websocketEndpoint = "/mqtt",
     protocols = listOf("mqtt"),
 )
+
+connectTcpWebSocket(options, binaryCodec = BinaryPassThroughCodec).use { ws ->
+    ws.send(WebSocketMessage.Binary(encodeConnectPacket()))     // a ReadBuffer of MQTT bytes
+
+    ws.receive().collect { message ->
+        if (message is WebSocketMessage.Binary) {
+            handlePacket(decodeMqttPacket(message.payload))     // payload: ReadBuffer
+        }
+    }
+}
 ```
 
-## Subprotocol Negotiation
+Better still, supply a real MQTT `Codec<MqttPacket>` as `binaryCodec` and let `receive()` hand you
+decoded packets directly — see [Typed messages with codecs](../recipes/typed-messages-with-codecs.md).
 
-MQTT brokers typically require the `mqtt` or `mqttv3.1` subprotocol to be specified in the WebSocket handshake. The `protocols` parameter adds the `Sec-WebSocket-Protocol` header:
+## Subprotocol negotiation
+
+The `protocols` list becomes the `Sec-WebSocket-Protocol` header. Most brokers require it:
 
 ```kotlin
-// MQTT 3.1.1
-protocols = listOf("mqttv3.1")
-
-// MQTT 5.0
-protocols = listOf("mqtt")
-
-// Accept either
-protocols = listOf("mqtt", "mqttv3.1")
+protocols = listOf("mqtt")               // MQTT 5.0 / 3.1.1 over WS (RFC-registered name)
+protocols = listOf("mqttv3.1")           // legacy brokers
+protocols = listOf("mqtt", "mqttv3.1")   // offer both; server picks
 ```

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -7,52 +7,73 @@ sidebar_position: 1
 
 # WebSocket
 
-A Kotlin Multiplatform WebSocket client library providing RFC 6455 compliant WebSocket functionality across JVM, Android, iOS, macOS, Linux, and JavaScript platforms.
+A composable, RFC 6455 WebSocket client for Kotlin Multiplatform — one API on JVM, Android, iOS,
+macOS, tvOS, watchOS, Linux, Node.js, and the browser, each delegating to the best native transport.
+
+You get a single `connect*` call that returns a typed `Connection<WebSocketMessage<B>>`: `send` and
+`receive` messages as a Kotlin `Flow`, decode binary frames into *your own types* with a pluggable
+codec, and — because it composes on top of [`socket`](https://github.com/DitchOoM/socket) — drop
+WebSocket in as a rung of a transport fallback chain.
 
 ## Features
 
-- **RFC 6455 Compliant** - Full WebSocket protocol implementation with frame parsing, masking, and fragmentation
-- **Kotlin Multiplatform** - Single API across all major platforms
-- **permessage-deflate** - RFC 7692 compression extension with configurable window bits and context takeover
-- **Auto-Reconnection** - Built-in `ReconnectingWebSocketClient` with pluggable retry classification
-- **Sealed Exceptions** - `WebSocketException` hierarchy for deterministic error handling
-- **Zero-Copy Pipeline** - Minimal allocations with direct buffer operations and SIMD-optimized masking
-- **Native Platform Support** - Apple Network.framework (NWConnection) and browser WebSocket API
-- **Flow-Based Messaging** - Kotlin Flow for incoming messages with typed channels (text, binary, all)
+- **RFC 6455 compliant** — frame parsing, masking, fragmentation, close handshake. Passes all 517
+  [Autobahn](https://github.com/crossbario/autobahn-testsuite) test cases.
+- **One API, native transports** — NIO2 on JVM/Android, Network.framework on Apple, io_uring/epoll
+  on Linux, native `WebSocket` in the browser.
+- **Typed messages via codecs** — binary frames decode through a `Codec<B>` you supply, so you work
+  with your own types, not raw bytes. See [Typed messages with codecs](recipes/typed-messages-with-codecs.md).
+- **Composable as a transport** — `WebSocketTransport` *is* a `socket` `Transport`, usable as the
+  always-reachable floor of a QUIC → WebTransport → TCP → WebSocket fallback. See
+  [WebSocket as a transport](recipes/websocket-as-transport.md).
+- **permessage-deflate** — RFC 7692 compression with context takeover and configurable window bits
+  where the platform allows.
+- **Zero-copy pipeline** — direct `ReadBuffer`/`WriteBuffer` I/O with SIMD-optimized masking; no
+  intermediate `ByteArray` copies.
+- **Sealed exceptions** — a `WebSocketException` hierarchy for precise error handling.
+- **Network-aware reconnection** — compose with `socket`'s `ReconnectingConnection` for backoff that
+  reacts to real network path changes. See [Reconnection](core-concepts/reconnection.md).
 
-## Installation
-
-Add the dependency to your `build.gradle.kts`:
+## Install
 
 ```kotlin
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("com.ditchoom:websocket:2.0.0")
+            implementation("com.ditchoom:websocket-tcp:<latest-version>")
         }
     }
 }
 ```
 
+Pick the module that matches how you connect:
+
+| Module | Entry point | Use when |
+|--------|-------------|----------|
+| `websocket-tcp` | `connectTcpWebSocket(options)`, `WebSocketTransport` | JVM/Android/Apple/Linux/Node.js over raw TCP+TLS; or composing a transport chain |
+| `websocket-apple` | `connectAppleNativeWebSocket(options)` | Apple platforms wanting the smallest binary and system-managed TLS/proxy |
+| `websocket` | `connectWebSocket(byteStream, options)`, `connectBrowserWebSocket(options)` | Bring-your-own `ByteStream`, or the browser |
+
+Find the latest version on [Maven Central](https://central.sonatype.com/artifact/com.ditchoom/websocket).
+
 ## Supported Platforms
 
-| Platform | Targets | Implementation |
-|----------|---------|----------------|
-| JVM | `jvm` | RFC 6455 (DefaultWebSocketClient) |
-| Android | `android` | RFC 6455 (DefaultWebSocketClient) |
-| iOS | `iosArm64`, `iosSimulatorArm64`, `iosX64` | Network.framework or RFC 6455 |
-| macOS | `macosArm64`, `macosX64` | Network.framework or RFC 6455 |
-| tvOS | `tvosArm64`, `tvosSimulatorArm64`, `tvosX64` | Network.framework or RFC 6455 |
-| watchOS | `watchosArm64`, `watchosSimulatorArm64`, `watchosX64` | Network.framework or RFC 6455 |
-| Linux | `linuxX64`, `linuxArm64` | RFC 6455 (DefaultWebSocketClient) |
-| JavaScript | `js` (Node.js) | RFC 6455 (DefaultWebSocketClient) |
-| JavaScript | `js` (Browser) | Browser WebSocket API |
+| Platform | Targets | Transport |
+|----------|---------|-----------|
+| JVM | `jvm` | NIO2 `AsynchronousSocketChannel` |
+| Android | `android` | NIO2 (same as JVM) |
+| iOS / macOS / tvOS / watchOS | `iosArm64`, `iosSimulatorArm64`, `iosX64`, `macosArm64`, `macosX64`, `tvos*`, `watchos*` | `NWConnection`, or `NSURLSessionWebSocketTask` (`websocket-apple`) |
+| Linux | `linuxX64`, `linuxArm64` | io_uring or epoll |
+| JavaScript | `js` (Node.js) | raw socket, RFC 6455 engine |
+| JavaScript | `js` (Browser) | native `WebSocket` |
 
-## Dependencies
+## Part of the DitchOoM stack
 
 This library builds on:
 
-- [`com.ditchoom:buffer`](https://github.com/DitchOoM/buffer) - Platform buffer abstraction with compression
-- [`com.ditchoom:socket`](https://github.com/DitchOoM/socket) - Platform socket implementation with TLS
+- [`com.ditchoom:buffer`](https://github.com/DitchOoM/buffer) — zero-copy `ReadBuffer`/`WriteBuffer`
+  and `buffer-codec` (the `Codec<B>` your binary frames run through).
+- [`com.ditchoom:socket`](https://github.com/DitchOoM/socket) — TCP + TLS + transport fallback
+  (`WebSocketTransport` plugs in here; `ReconnectingConnection` wraps a WebSocket connection).
 
-These are pulled in transitively - you only need to add the websocket dependency.
+Both are pulled in transitively — you only add the `websocket*` dependency.

--- a/docs/docs/platforms/apple.md
+++ b/docs/docs/platforms/apple.md
@@ -6,49 +6,61 @@ sidebar_position: 2
 
 # Apple Platforms
 
-## Implementation
+Apple targets have **two** ways to connect, and both return the same
+`Connection<WebSocketMessage<B>>` — so the rest of your code is identical to every other platform.
 
-On Apple platforms, the library provides two WebSocket implementations:
+## Option 1 — RFC 6455 engine over a socket (`websocket-tcp`)
 
-1. **`DefaultWebSocketClient`** (default) - Full RFC 6455 implementation with compression support
-2. **`NativeWebSocketConnection`** - Apple Network.framework (`NWConnection` + `nw_protocol_websocket`) for lightweight connections
-
-## Default Client
-
-The standard `WebSocketClient.allocate()` returns `DefaultWebSocketClient`, which provides the full feature set including `permessage-deflate` compression:
+`connectTcpWebSocket` runs this library's own RFC 6455 engine on top of a `socket` transport
+(Network.framework `NWConnection`). This is the portable choice — the same call works on JVM,
+Android, Linux, and Node.js — and it gives you full control over permessage-deflate.
 
 ```kotlin
-val client = WebSocketClient.allocate(options)
-client.connect()
-```
+import com.ditchoom.websocket.tcp.connectTcpWebSocket
 
-## Native WebSocket Connection
-
-For lightweight use cases that don't need compression, use the platform-native implementation directly:
-
-```kotlin
-val native = connectNativeWebSocket(
-    url = "wss://example.com/ws",
-    tls = true,
-    verifyCertificates = true,
-    autoReplyPing = true,
-    subprotocols = listOf("mqtt"),
-    timeoutSeconds = 30,
-)
-
-// Lower-level API using opcodes
-val message = native.receiveMessage()
-when (message.opcode) {
-    NativeWebSocketConnection.OPCODE_TEXT -> // text
-    NativeWebSocketConnection.OPCODE_BINARY -> // binary
-    NativeWebSocketConnection.OPCODE_CLOSE -> // close
+connectTcpWebSocket(options).use { ws ->
+    ws.send(WebSocketMessage.Text("hello"))
+    val reply = ws.receive().first()
 }
-
-native.close()
 ```
 
-The native implementation uses Apple's Network.framework which handles TLS, HTTP upgrade, and frame parsing at the OS level.
+## Option 2 — system WebSocket (`websocket-apple`)
+
+`connectAppleNativeWebSocket` is backed by `NSURLSessionWebSocketTask`, so the **system** handles TLS,
+proxies, and permessage-deflate. It has the smallest binary (no `socket` dependency) and integrates
+with URLSession configuration — ideal for an app already living in the Apple networking stack.
+
+```kotlin
+import com.ditchoom.websocket.apple.connectAppleNativeWebSocket
+
+val ws = connectAppleNativeWebSocket(
+    connectionOptions = options,
+    // optional: handle TLS auth challenges (client certs, pinning)
+    authChallengeHandler = { challenge -> resolveCredential(challenge) },
+)
+ws.use { /* send / receive as usual */ }
+```
+
+Both take an optional `binaryCodec: Codec<B>` and `parentScope: CoroutineScope?`, exactly like
+`connectTcpWebSocket`.
+
+## Which to choose
+
+| | `connectTcpWebSocket` (`websocket-tcp`) | `connectAppleNativeWebSocket` (`websocket-apple`) |
+|---|---|---|
+| Backing | RFC 6455 engine over `NWConnection` | `NSURLSessionWebSocketTask` |
+| TLS / proxy / deflate | this library | the OS |
+| Binary size | larger (pulls in `socket`) | smallest |
+| Portability | identical call on all platforms | Apple-only |
+| Best for | shared multiplatform code, deflate control | Apple-native apps, URLSession integration |
 
 ## Compression
 
-Apple platforms support `permessage-deflate` with context takeover via zlib but do not support custom window bits through the DefaultWebSocketClient. The native `NWConnection` implementation delegates compression to the OS.
+Apple supports `permessage-deflate` with context takeover, but not custom window bits. With
+`websocket-apple` the OS owns compression entirely; with `websocket-tcp` this library negotiates and
+runs it via zlib.
+
+> There is also a lower-level `connectNativeWebSocket` primitive (raw `NWConnection` +
+> `nw_protocol_websocket`) that returns a platform-native `NativeWebSocketConnection` rather than a
+> `Connection<…>`. It underlies the Apple path and is not the recommended entry point — prefer the
+> two `Connection`-returning functions above.

--- a/docs/docs/recipes/typed-messages-with-codecs.md
+++ b/docs/docs/recipes/typed-messages-with-codecs.md
@@ -1,0 +1,106 @@
+---
+id: typed-messages-with-codecs
+title: Typed Messages with Codecs
+sidebar_position: 1
+---
+
+# Typed Messages with Codecs
+
+Most WebSocket libraries hand you a `ByteArray` or `ByteBuffer` for binary frames and leave parsing
+to you. Here, **binary frames run a `Codec<B>` you supply**, so `receive()` emits your own decoded
+type and `send()` takes it — the generic threads all the way through as
+`Connection<WebSocketMessage<B>>`.
+
+Text frames are always `String` (RFC 6455 §5.6 mandates UTF-8); only **binary** frames run the codec.
+
+## Supplying a codec
+
+Every `connect*` function takes an optional `binaryCodec`:
+
+```kotlin
+val ws: Connection<WebSocketMessage<SensorReading>> =
+    connectTcpWebSocket(options, binaryCodec = SensorReadingCodec)
+
+ws.send(WebSocketMessage.Binary(SensorReading(id = 7u, celsius = 21)))
+
+ws.receive().collect { msg ->
+    when (msg) {
+        is WebSocketMessage.Binary -> update(msg.payload)   // payload: SensorReading, already decoded
+        is WebSocketMessage.Text   -> log(msg.payload)      // still a String
+        else -> {}
+    }
+}
+```
+
+Omit `binaryCodec` and you get the default `EmptyCodec` — binary payloads are discarded and `B` is
+`Unit`.
+
+## Built-in codecs
+
+`com.ditchoom.websocket.codecs`:
+
+| Codec | `B` | Behavior |
+|-------|-----|----------|
+| `EmptyCodec` | `Unit` | Default — discards binary payloads (text-only apps) |
+| `BinaryPassThroughCodec` | `ReadBuffer` | Raw bytes, copied into a consumer-owned buffer you can read/free |
+| `RejectingCodec` | `Nothing` | Throws on any binary frame — assert "this endpoint is text-only" and fail loudly |
+
+```kotlin
+// Raw bytes:
+connectTcpWebSocket(options, binaryCodec = BinaryPassThroughCodec).use { ws ->
+    ws.receive().collect { msg ->
+        if (msg is WebSocketMessage.Binary) processBytes(msg.payload)   // payload: ReadBuffer
+    }
+}
+```
+
+## Generated codecs (buffer-codec)
+
+The cleanest way to get a `Codec<B>` is to let [`buffer-codec`](https://github.com/DitchOoM/buffer)
+generate one from an annotated data class — no hand-written field wiring:
+
+```kotlin
+@ProtocolMessage
+data class SensorReading(
+    val id: UShort,                 // 2 bytes
+    val celsius: Int,               // 4 bytes
+    @LengthPrefixed val label: String,
+)
+// The KSP processor generates `object SensorReadingCodec : Codec<SensorReading>`.
+
+connectTcpWebSocket(options, binaryCodec = SensorReadingCodec)
+```
+
+Because generated and hand-written codecs implement the same `Codec<T>`, they drop into
+`binaryCodec` interchangeably.
+
+## Writing a custom codec
+
+A `Codec<T>` is two methods over `ReadBuffer`/`WriteBuffer`:
+
+```kotlin
+object FrameCountCodec : Codec<Int> {
+    override fun decode(buffer: ReadBuffer, context: DecodeContext): Int = buffer.readInt()
+
+    override fun encode(buffer: WriteBuffer, value: Int, context: EncodeContext) {
+        buffer.writeInt(value)
+    }
+}
+
+connectTcpWebSocket(options, binaryCodec = FrameCountCodec)
+```
+
+Notes that make this safe and allocation-friendly:
+
+- **Decode runs after fragment reassembly**, on the fully-defragmented payload — you never handle
+  continuation frames.
+- The wire buffer is **freed before your decoded value is emitted**, so what `receive()` gives you
+  never aliases a library buffer.
+- Need to allocate a destination buffer in `decode`? Pull the connection's own `BufferFactory` out
+  of the `DecodeContext` under `WsBufferFactoryKey`, so your codec allocates from the same pool as
+  the wire path (this is exactly how `BinaryPassThroughCodec` gets its buffers):
+
+  ```kotlin
+  val factory = context[WsBufferFactoryKey] ?: BufferFactory.Default
+  val out = factory.allocate(size)
+  ```

--- a/docs/docs/recipes/websocket-as-transport.md
+++ b/docs/docs/recipes/websocket-as-transport.md
@@ -1,0 +1,74 @@
+---
+id: websocket-as-transport
+title: WebSocket as a Transport
+sidebar_position: 2
+---
+
+# WebSocket as a Transport
+
+`connectWebSocket` *takes* a byte stream and gives you WebSocket messages. `WebSocketTransport` is the
+**inverse**: it *is* a `socket` `Transport` that *returns* a `ByteStream` whose bytes ride binary
+WebSocket frames. That flip is what lets WebSocket be the always-reachable floor of a transport
+fallback chain — when hostile middleboxes block QUIC, WebTransport, and even plain TCP, a `wss://:443`
+connection usually still gets through.
+
+```
+QUIC  →  WebTransport  →  TCP  →  WebSocket    (fall down the list until one connects)
+```
+
+## The transport
+
+```kotlin
+import com.ditchoom.websocket.tcp.WebSocketTransport
+
+val transport = WebSocketTransport(
+    websocketEndpoint = "/tunnel",
+    protocols = emptyList(),
+    requestCompression = false,
+    compressionOptions = CompressionOptions(),
+    underlying = TcpTransport(),      // the WS handshake rides this transport; TLS follows config.tls
+)
+
+// A Transport exposes exactly one method:
+val stream: ByteStream = transport.connect(host, port, config)
+```
+
+Per-connection addressing (endpoint, subprotocols, compression) is fixed at **construction**, so
+`connect()` only takes the uniform `(hostname, port, config)` surface every other transport uses —
+which is precisely what makes it substitutable in a fallback chain.
+
+## Byte-stream semantics
+
+The returned `ByteStream` tunnels raw bytes over WebSocket, transparently to whatever protocol runs
+on top:
+
+- `write(buffer)` → **one binary WebSocket frame** per call
+- `read()` → the next data payload (`ReadResult.Data`); text frames surface as their UTF-8 bytes
+- Ping/Pong are invisible — auto-answered by the connection
+- A peer Close or EOF surfaces as `ReadResult.End`
+
+```kotlin
+stream.write(requestBytes)
+val response = stream.read()          // ReadResult.Data / ReadResult.End
+```
+
+## In a fallback chain
+
+Because it implements the same `Transport` interface as `TcpTransport` (and the QUIC/WebTransport
+rungs), `WebSocketTransport` drops into a `socket` `FallbackTransport` as the last resort:
+
+```kotlin
+// Sketch — see the socket docs for the exact FallbackTransport API.
+val transport = FallbackTransport(
+    QuicTransport(),
+    WebTransportTransport(),
+    TcpTransport(),
+    WebSocketTransport(websocketEndpoint = "/tunnel"),   // universal floor
+)
+val stream = transport.connect(host, 443, config)
+```
+
+Anything that speaks to a `ByteStream` — an MQTT client, a custom RPC framing, a database protocol —
+now runs unchanged over whichever rung connects. See the
+[socket documentation](https://ditchoom.github.io/socket/) for building fallback chains, and
+[MQTT over WebSocket](../guides/mqtt-over-websocket.md) for a concrete consumer.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -16,6 +16,14 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'Recipes',
+      items: [
+        'recipes/typed-messages-with-codecs',
+        'recipes/websocket-as-transport',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Guides',
       items: [
         'guides/mqtt-over-websocket',


### PR DESCRIPTION
## Why

The README and the entire Docusaurus site taught an API that **does not exist** in the codebase —
`WebSocketClient.allocate(o).connect()`, `client.write(...)`, `client.incomingMessages` /
`incomingTextMessages` / `incomingBinaryMessages`, `ReconnectingWebSocketClient`, `ConnectionState`,
`client.ping()`. Anyone following the docs wrote code that doesn't compile.

The real surface is `connect*` → `Connection<WebSocketMessage<B>>` with `send` / `receive(): Flow` /
`close` and the `use { }` extension. This PR rewrites the docs to that surface and, modeled on the
[buffer](https://github.com/DitchOoM/buffer) docs, showcases the two things that actually
differentiate this library: **typed binary messages via a pluggable `Codec<B>`**, and
**`WebSocketTransport` as a `socket` transport rung** (QUIC → WebTransport → TCP → WebSocket fallback).

## Changes

**README** — rewritten to the buffer bar: why-table (vs OkHttp/Ktor/platform WS), modules table
(`websocket`, `websocket-tcp`, `websocket-apple`), correct quick start, the two composability
showcases, compression, sealed-`WebSocketException` handling, platform table, and the DitchOoM stack
diagram.

**Docusaurus** — all fictional pages rewritten to the real API:
- `intro`, `getting-started` — correct tutorial + entry-point chooser + real feature list.
- `core-concepts/connection-lifecycle` — honest `connect → live → close`-handshake (5s bounded);
  `receive()` completes on close; `use {}`.
- `core-concepts/error-handling` — fixed examples; dropped the fictional `ConnectionState` section
  (the sealed hierarchy + close codes were already correct).
- `core-concepts/reconnection` — **rewritten to the real story**: socket's `ReconnectingConnection<T>`
  composing over a WebSocket connection with network-aware backoff (`RetryAfter`/`GiveUp`).
- `guides/mqtt-over-websocket`, `platforms/apple` — corrected to `connect*` / codecs / transport API.
- **New `recipes/`**: `typed-messages-with-codecs` and `websocket-as-transport`; wired into `sidebars.ts`.
- `core-concepts/compression` was already accurate — left as-is.

All internal `.md` links verified to resolve. Content checked against the actual public API in
`src/commonMain/.../websocket/` (and socket's `ReconnectingConnection`).

## Notes

- Docs-only; no source changes. Based off `main` — independent of the deps bump in #19.
- Draft for review of the copy/structure before merge.
