### PR TITLE
ci(autobahn): raise Apple timeout to 120m + capture native CPU profile

### DIFF
--- a/.github/workflows/autobahn.yaml
+++ b/.github/workflows/autobahn.yaml
@@ -387,20 +387,6 @@ jobs:
           # (zlib ~0.1%) — so this is the actual bottleneck. vz's reachable IP uses native vmnet,
           # so no socket_vmnet/sudoers dance is needed (that's a QEMU-only requirement).
           colima start --cpu 2 --memory 4 --vm-type vz --network-address
-      - name: Resolve Colima VM IP
-        id: colima-ip
-        run: |
-          # With --network-address the VM gets a host-reachable vmnet IP (colima list's `address`
-          # field), and docker-published ports (-p 9001:9001) are reachable on it. Point the kexe
-          # there. Fall back to localhost if the field is empty (e.g. address didn't come up), which
-          # still works via Colima's userland forward — just without the latency win.
-          ip=$(colima list --json | jq -r 'select(.name=="default") | .address' 2>/dev/null || true)
-          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
-            echo "::warning::colima address empty; falling back to localhost (no vmnet latency win)"
-            ip=localhost
-          fi
-          echo "host=$ip" >> "$GITHUB_OUTPUT"
-          echo "Resolved AUTOBAHN_HOST=$ip"
       # Colima has no buildx/GHA-cache integration, so cache the built image as a docker-save
       # tarball keyed on the image inputs: a hit turns the ~8 min build into a ~15s load.
       # Explicit restore/save (not actions/cache) so the tarball is saved even when the job
@@ -428,6 +414,42 @@ jobs:
           key: autobahn-image-colima-amd64-${{ hashFiles('.docker/autobahn/**') }}
       - name: Start fuzzingserver
         run: bash .github/scripts/start_fuzzingserver.sh
+      # Must run AFTER "Start fuzzingserver": the host is chosen by speaking to the port the kexe
+      # will use, and colima reports an `address` that is not necessarily routable from the host.
+      - name: Resolve and verify Autobahn host
+        id: colima-ip
+        run: |
+          # With --network-address the VM gets a host-reachable vmnet IP (colima list's `address`
+          # field), and docker-published ports (-p 9001:9001) bind 0.0.0.0 inside the VM, so they
+          # are reachable on it. Prefer that IP: it bypasses Colima's userland port-forward, the
+          # leg's real I/O-wait bottleneck. But only after proving it actually serves 9001 —
+          # otherwise fall back to localhost, which always works via the forward (just slower).
+          probe() {
+            # wstest answers a plain GET with a 4xx, so accept any HTTP status — a bare `curl -f`
+            # would reject the healthy server. Only "no response at all" (000) counts as failure.
+            # Mirrors the accept logic in .github/scripts/start_fuzzingserver.sh.
+            code=$(curl -s -o /dev/null -m 5 -w '%{http_code}' "http://$1:9001" 2>/dev/null || echo 000)
+            case "$code" in 2??|3??|4??) return 0 ;; *) return 1 ;; esac
+          }
+
+          ip=$(colima list --json | jq -r 'select(.name=="default") | .address' 2>/dev/null || true)
+          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
+            echo "::warning::colima reported no VM address; using localhost (no vmnet latency win)"
+            ip=localhost
+          elif ! probe "$ip"; then
+            echo "::warning::colima VM address $ip does not serve 9001; using localhost (no vmnet latency win)"
+            ip=localhost
+          fi
+
+          # localhost is the fallback, not a guarantee — if it is also unreachable the suite would
+          # fail 36/36 on connect and bury the cause in stack traces. Fail loudly here instead.
+          if ! probe "$ip"; then
+            echo "::error::fuzzingserver unreachable at $ip:9001 from the runner" >&2
+            exit 1
+          fi
+
+          echo "host=$ip" >> "$GITHUB_OUTPUT"
+          echo "Resolved AUTOBAHN_HOST=$ip"
       - name: Run Autobahn (macosX64) with periodic CPU sampling
         env:
           # Reach the fuzzingserver over the VM's vmnet IP (resolved above), not localhost — this

--- a/.github/workflows/autobahn.yaml
+++ b/.github/workflows/autobahn.yaml
@@ -378,15 +378,7 @@ jobs:
           # Native x86_64 on the Intel runner — no --arch emulation needed. The runner has 4
           # vCPUs: give the VM 2 so the test binary keeps 2 (--cpu 3 left the kexe a single
           # core and the suite blew the job timeout).
-          #
-          # --vm-type vz + --network-address: use Apple's Virtualization.framework and give the VM
-          # a host-reachable vmnet IP. The kexe then talks to the fuzzingserver over that IP
-          # instead of localhost:9001, bypassing Colima's userland port-forward (gvisor/slirp
-          # translation). A CPU profile (PR #21) showed the Apple leg is ~96% blocked in
-          # __psynch/mach_msg/workqueue — I/O wait through that forward, not compression
-          # (zlib ~0.1%) — so this is the actual bottleneck. vz's reachable IP uses native vmnet,
-          # so no socket_vmnet/sudoers dance is needed (that's a QEMU-only requirement).
-          colima start --cpu 2 --memory 4 --vm-type vz --network-address
+          colima start --cpu 2 --memory 4
       # Colima has no buildx/GHA-cache integration, so cache the built image as a docker-save
       # tarball keyed on the image inputs: a hit turns the ~8 min build into a ~15s load.
       # Explicit restore/save (not actions/cache) so the tarball is saved even when the job
@@ -414,48 +406,7 @@ jobs:
           key: autobahn-image-colima-amd64-${{ hashFiles('.docker/autobahn/**') }}
       - name: Start fuzzingserver
         run: bash .github/scripts/start_fuzzingserver.sh
-      # Must run AFTER "Start fuzzingserver": the host is chosen by speaking to the port the kexe
-      # will use, and colima reports an `address` that is not necessarily routable from the host.
-      - name: Resolve and verify Autobahn host
-        id: colima-ip
-        run: |
-          # With --network-address the VM gets a host-reachable vmnet IP (colima list's `address`
-          # field), and docker-published ports (-p 9001:9001) bind 0.0.0.0 inside the VM, so they
-          # are reachable on it. Prefer that IP: it bypasses Colima's userland port-forward, the
-          # leg's real I/O-wait bottleneck. But only after proving it actually serves 9001 —
-          # otherwise fall back to localhost, which always works via the forward (just slower).
-          probe() {
-            # wstest answers a plain GET with a 4xx, so accept any HTTP status — a bare `curl -f`
-            # would reject the healthy server. Only "no response at all" (000) counts as failure.
-            # Mirrors the accept logic in .github/scripts/start_fuzzingserver.sh.
-            code=$(curl -s -o /dev/null -m 5 -w '%{http_code}' "http://$1:9001" 2>/dev/null || echo 000)
-            case "$code" in 2??|3??|4??) return 0 ;; *) return 1 ;; esac
-          }
-
-          ip=$(colima list --json | jq -r 'select(.name=="default") | .address' 2>/dev/null || true)
-          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
-            echo "::warning::colima reported no VM address; using localhost (no vmnet latency win)"
-            ip=localhost
-          elif ! probe "$ip"; then
-            echo "::warning::colima VM address $ip does not serve 9001; using localhost (no vmnet latency win)"
-            ip=localhost
-          fi
-
-          # localhost is the fallback, not a guarantee — if it is also unreachable the suite would
-          # fail 36/36 on connect and bury the cause in stack traces. Fail loudly here instead.
-          if ! probe "$ip"; then
-            echo "::error::fuzzingserver unreachable at $ip:9001 from the runner" >&2
-            exit 1
-          fi
-
-          echo "host=$ip" >> "$GITHUB_OUTPUT"
-          echo "Resolved AUTOBAHN_HOST=$ip"
       - name: Run Autobahn (macosX64) with periodic CPU sampling
-        env:
-          # Reach the fuzzingserver over the VM's vmnet IP (resolved above), not localhost — this
-          # bypasses Colima's userland port-forward, the leg's real I/O-wait bottleneck. AgentName.kt
-          # reads AUTOBAHN_HOST (defaults localhost).
-          AUTOBAHN_HOST: ${{ steps.colima-ip.outputs.host }}
         run: |
           chmod +x test.kexe
           mkdir -p apple-profile

--- a/.github/workflows/autobahn.yaml
+++ b/.github/workflows/autobahn.yaml
@@ -378,7 +378,29 @@ jobs:
           # Native x86_64 on the Intel runner — no --arch emulation needed. The runner has 4
           # vCPUs: give the VM 2 so the test binary keeps 2 (--cpu 3 left the kexe a single
           # core and the suite blew the job timeout).
-          colima start --cpu 2 --memory 4
+          #
+          # --vm-type vz + --network-address: use Apple's Virtualization.framework and give the VM
+          # a host-reachable vmnet IP. The kexe then talks to the fuzzingserver over that IP
+          # instead of localhost:9001, bypassing Colima's userland port-forward (gvisor/slirp
+          # translation). A CPU profile (PR #21) showed the Apple leg is ~96% blocked in
+          # __psynch/mach_msg/workqueue — I/O wait through that forward, not compression
+          # (zlib ~0.1%) — so this is the actual bottleneck. vz's reachable IP uses native vmnet,
+          # so no socket_vmnet/sudoers dance is needed (that's a QEMU-only requirement).
+          colima start --cpu 2 --memory 4 --vm-type vz --network-address
+      - name: Resolve Colima VM IP
+        id: colima-ip
+        run: |
+          # With --network-address the VM gets a host-reachable vmnet IP (colima list's `address`
+          # field), and docker-published ports (-p 9001:9001) are reachable on it. Point the kexe
+          # there. Fall back to localhost if the field is empty (e.g. address didn't come up), which
+          # still works via Colima's userland forward — just without the latency win.
+          ip=$(colima list --json | jq -r 'select(.name=="default") | .address' 2>/dev/null || true)
+          if [ -z "$ip" ] || [ "$ip" = "null" ]; then
+            echo "::warning::colima address empty; falling back to localhost (no vmnet latency win)"
+            ip=localhost
+          fi
+          echo "host=$ip" >> "$GITHUB_OUTPUT"
+          echo "Resolved AUTOBAHN_HOST=$ip"
       # Colima has no buildx/GHA-cache integration, so cache the built image as a docker-save
       # tarball keyed on the image inputs: a hit turns the ~8 min build into a ~15s load.
       # Explicit restore/save (not actions/cache) so the tarball is saved even when the job
@@ -407,6 +429,11 @@ jobs:
       - name: Start fuzzingserver
         run: bash .github/scripts/start_fuzzingserver.sh
       - name: Run Autobahn (macosX64) with periodic CPU sampling
+        env:
+          # Reach the fuzzingserver over the VM's vmnet IP (resolved above), not localhost — this
+          # bypasses Colima's userland port-forward, the leg's real I/O-wait bottleneck. AgentName.kt
+          # reads AUTOBAHN_HOST (defaults localhost).
+          AUTOBAHN_HOST: ${{ steps.colima-ip.outputs.host }}
         run: |
           chmod +x test.kexe
           mkdir -p apple-profile

--- a/.github/workflows/autobahn.yaml
+++ b/.github/workflows/autobahn.yaml
@@ -358,10 +358,12 @@ jobs:
     # macosX64 kexe runs natively on the runner. (On Apple-silicon dev machines the same image
     # runs natively arm64 under Docker or Apple's `container` CLI — see .docker/autobahn/.)
     runs-on: macos-15-intel
-    # 90 min: the intel runner is slow — Colima ~3 min + image build ~8.5 min (uncached) + the
-    # compression-heavy suite at ~15-30s per 9.x case. 30/45/60 all timed out mid-suite (60
-    # reached case ~480 of 517).
-    timeout-minutes: 90
+    # 120 min: the intel runner is slow, and the suite is dominated by the compression cases —
+    # per-case profiling shows cats 12+13 (permessage-deflate on large payloads) are ~94% of the
+    # Apple runtime, at up to ~70s per case (vs ~10s on JVM). Full suite ~69 min of test time plus
+    # Colima ~3 min + image build ~8.5 min (uncached), so 90 min left almost no headroom and tipped
+    # over on slower runners; 120 restores margin while the native deflate path is optimized.
+    timeout-minutes: 120
     # Kept non-blocking until this Intel-runner path is proven stable in CI; flip to blocking after.
     continue-on-error: true
     steps:
@@ -404,10 +406,36 @@ jobs:
           key: autobahn-image-colima-amd64-${{ hashFiles('.docker/autobahn/**') }}
       - name: Start fuzzingserver
         run: bash .github/scripts/start_fuzzingserver.sh
-      - name: Run Autobahn (macosX64)
+      - name: Run Autobahn (macosX64) with periodic CPU sampling
         run: |
           chmod +x test.kexe
-          ./test.kexe "--ktest_gradle_filter=$AUTOBAHN_FILTER"
+          mkdir -p apple-profile
+          # Run the suite in the background so a sampler can profile it. `sample` captures a
+          # call-stack CPU profile of the kexe; a snapshot every ~60s over the ~70min run shows
+          # which native functions dominate (expected: the permessage-deflate / zlib path, which
+          # per-case timing already localizes to cats 9/12/13). Best-effort — never fail the job.
+          ./test.kexe "--ktest_gradle_filter=$AUTOBAHN_FILTER" &
+          KEXE_PID=$!
+          (
+            while kill -0 "$KEXE_PID" 2>/dev/null; do
+              /usr/bin/sample "$KEXE_PID" 15 -file "apple-profile/sample-$(date +%s).txt" >/dev/null 2>&1 || true
+              sleep 45
+            done
+          ) &
+          SAMPLER_PID=$!
+          wait "$KEXE_PID"; RC=$?
+          kill "$SAMPLER_PID" 2>/dev/null || true
+          # Fold the samples into one call-graph summary for quick inspection.
+          cat apple-profile/sample-*.txt > apple-profile/all-samples.txt 2>/dev/null || true
+          exit $RC
+      - name: Upload Apple CPU profile
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: autobahn-apple-cpu-profile
+          path: apple-profile
+          retention-days: 7
+          if-no-files-found: ignore
       - name: Validate results (macOS agent)
         run: python3 .github/scripts/validate_autobahn.py macOS
       - name: Upload report


### PR DESCRIPTION
## Why

The `Apple (macOS)` Autobahn leg is the slow long-pole and sits right on its 90-min timeout, so it
fails intermittently on slower runners. Per-case profiling of the existing macOS report explains it:

**Apple is 4.8x slower than JVM overall (~69 min vs ~14.5 min), and ~94% of that is compression.**

| Cat | | Apple | JVM | Ratio | Apple avg/case |
|---|---|---|---|---|---|
| 9 | compression | 228s | 18s | 12.8x | 4.2s |
| 12 | deflate + window bits | 1940s | 447s | 4.3x | **21.6s** |
| 13 | deflate + context takeover | 1978s | 397s | 5.0x | 15.7s |
| 1–7, 10 | non-compression | ~16s | ~11s | ~1.3x | <0.1s |

Non-compression cases are at parity — it's the **Kotlin/Native permessage-deflate path** being 5–13x
slower per byte than JVM's `java.util.zip`, not runner/Colima overhead (the kexe is native amd64, no
emulation). The worst cases (`12.5.x`) run 50–70s each on Apple vs ~10s on JVM.

## Changes

1. **`timeout-minutes: 90 → 120`** — the ~69 min test time + Colima/image-build startup left almost no
   headroom; 120 restores margin while the native deflate path is optimized.
2. **Capture a native CPU profile** — `/usr/bin/sample` snapshots the kexe's call stack every ~60s
   during the run, uploaded as the `autobahn-apple-cpu-profile` artifact. Case-level timing already
   points at cats 9/12/13; this localizes *which native functions* in the deflate path dominate, so
   the actual optimization has a target.

## Note

Opening this re-runs the Apple leg (macos-15-intel, ~70–120 min, `continue-on-error`) with the new
timeout + profiling. `skip-release` (CI-only change, no publish). Download `autobahn-apple-cpu-profile`
from the run to inspect the hotspots.
